### PR TITLE
Solving REQUIREMENTS.txt installation error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,8 @@ For building HTML documentation you need the following packages:
 ```bash
 sudo apt update
 sudo apt install cmake python-pip
-sudo pip install -r REQUIREMENTS.txt
+sudo pip install wheel
+sudo pip install -r REQUIREMENTS.txt --upgrade
 ```
 
 For building the documentation as PDF the following packages need to be installed:


### PR DESCRIPTION
We have to add 
``` pip install wheel ```
and also,
have to change 
``` sudo pip install -r REQUIREMENTS.txt ```
with 
``` sudo pip install -r REQUIREMENTS.txt --upgrade ```
also add 
```  wheel>=0.33.6 ```
just ask the version above the default in the REQUIREMENTS.txt rather than asking it to be equal.
