### PR TITLE
Solving REQUIREMENTS.txt installation error no.2

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,6 +1,7 @@
-Sphinx==1.6.5
-sphinx-intl==0.9.11
-transifex-client==0.13.4
-#twitter==1.10.2
-sphinxcontrib-images==0.7.0
-sphinx_bootstrap_theme==0.4
+Sphinx>=1.6.5
+sphinx-intl>=0.9.11
+transifex-client>=0.13.4
+#twitter>=1.10.2
+sphinxcontrib-images>=0.7.0
+sphinx_bootstrap_theme>=0.4
+wheel>=0.33.6


### PR DESCRIPTION
We have to add 
``` pip install wheel ```
and also,
have to change 
``` sudo pip install -r REQUIREMENTS.txt ```
with 
``` sudo pip install -r REQUIREMENTS.txt --upgrade ```
in REUIREMENTS.txt
just ask the version above the default in the REQUIREMENTS.txt rather than asking it to be equal.
Also add 
``` wheel>=0.33.6 ```