### PR TITLE
solving REQUIREMENTS.txt installation error 2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,7 @@ For building HTML documentation you need the following packages:
 sudo apt update
 sudo apt install cmake python-pip
 sudo pip install -r REQUIREMENTS.txt
+sudo pip install wheel
 ```
 
 For building the documentation as PDF the following packages need to be installed:


### PR DESCRIPTION
The "wheel" installation must be added in the Readme.md
``` pip install wheel ```