### PR TITLE
Updated GitHub Actions script to update locale

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -86,14 +86,28 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Update locale
+        run: |
+          # List all the files that needs to be committed in build/docs/locale_changes.txt
+          awk '/^Update|^Create/{print $2}' build/docs/locale_changes.txt > tmp && mv tmp build/docs/locale_changes.txt        # .po files
+          cat build/docs/locale_changes.txt | perl -pe 's/(.*)en\/LC_MESSAGES(.*)/$1pot$2t/' >> build/docs/locale_changes.txt  # .pot files
+          cat build/docs/locale_changes.txt
+
+          # Add the files, commit and push
+          for line in `cat build/docs/locale_changes.txt`; do git add "$line"; done
+          git diff --staged --quiet || git commit -m "Update locale: commit ${{ env.GIT_HASH }}"
+          git fetch origin
+          git rebase origin/develop
+          git push origin develop
+
       - name: Update Documentation
         run: |
-          git checkout origin/gh-pages
+          git checkout -f origin/gh-pages
           git checkout -b gh-pages
           rm -rf dev
           cp -r build/docs/_build/html dev
           git add dev
-          git diff-index --quiet HEAD || git commit -m "Update documentation for develop: commit ${{ env.GIT_HASH }}"
+          git diff --staged --quiet || git commit -m "Update documentation for develop: commit ${{ env.GIT_HASH }}"
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -69,7 +69,7 @@ add_custom_target(locale ALL
   "${CMAKE_CURRENT_BINARY_DIR}"
   "${CMAKE_SOURCE_DIR}/locale/pot"
 
-  COMMAND sphinx-intl update -d ${CMAKE_SOURCE_DIR}/locale -l en
+  COMMAND sphinx-intl update -d ${CMAKE_SOURCE_DIR}/locale -l en > locale_changes.txt
   DEPENDS "conf.py"
 
   COMMENT "Generating POT & PO files ..."


### PR DESCRIPTION
Changes proposed in this pull request:
- Updated GitHub Actions script to automatically update locale for develop.
- Updates it on every push (or when a pull request is merged).

For testing on my fork,
- In the [develop](https://github.com/krashish8/pgrouting-workshop/commits/develop) branch, I made a dummy change (deleted locale for chapter-1, and modified chapter-2).
- Thereafter, the GitHub actions automatically updated the locale for chapter-1 and chapter-2.

@pgRouting/admins
