### PR TITLE
Added script to remove obsolete `#~` entries from `.po` English files

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -93,6 +93,9 @@ jobs:
           cat build/docs/locale_changes.txt | perl -pe 's/(.*)en\/LC_MESSAGES(.*)/$1pot$2t/' >> build/docs/locale_changes.txt  # .pot files
           cat build/docs/locale_changes.txt
 
+          # Remove obsolete entries #~ from .po files
+          tools/transifex/remove_obsolete_entries.sh
+
           # Add the files, commit and push
           for line in `cat build/docs/locale_changes.txt`; do git add "$line"; done
           git diff --staged --quiet || git commit -m "Update locale: commit ${{ env.GIT_HASH }}"

--- a/tools/transifex/remove_obsolete_entries.sh
+++ b/tools/transifex/remove_obsolete_entries.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# pgRouting Scripts
+# Copyright(c) pgRouting Contributors
+#
+# Remove all the obsolete entries, i.e. lines starting with #~ from .po files
+# ------------------------------------------------------------------------------
+
+# For all the chapter files
+for file in locale/en/LC_MESSAGES/chapters/*.po; do
+    if grep -q '#~' $file; then
+        perl -pi -0777 -e 's/#~.*//s' $file
+        git add $file
+    fi
+done
+
+# For the index.po file
+file=locale/en/LC_MESSAGES/index.po
+if grep -q '#~' $file; then
+    perl -pi -0777 -e 's/#~.*//s' $file
+    git add $file
+fi


### PR DESCRIPTION
Fixes #144.

Changes proposed in this pull request:
- Removes the obsolete entries `#~` from all `.po` English files, before updating the locale

In my fork, after pushing this commit to develop, the GitHub actions automatically removed the `#~` entries: https://github.com/krashish8/pgrouting-workshop/commit/d82adf64a92db69acf792a78344cab44cd1c308e

@pgRouting/admins
