### PR TITLE
Task 2: Append Name and Bio to Authors' List

### DIFF
--- a/docs/chapters/chapter-1.rst
+++ b/docs/chapters/chapter-1.rst
@@ -63,6 +63,8 @@ Alphabetical Order:
 * *Ko Nagase* works at `Georepublic <https://georepublic.info>`_  and works in Japan.
   tests of pgRouting project on Windows and Mac OSX environment.
   One of the contributors  of pgRoutingLayers for QGIS. OSGeo Charter member.
+* *Saurav Uppoor* is a Computer Engineering Undergraduate from University of Mumbai.
+  He loves solving algorithmic problems and contributing to open source.
 * *Stephen Woodbridge* works at the greater Boston, MA area.
   He was a pgrouting PSC member and developer. He develops solutions for mapping, geocoding,
   reverse geocoding, routing and processing of remote sensing imagery. OSGeo Charter member.


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Append Name and Bio to author's list as a prerequisite task to UN Challenge.

@pgRouting/admins
