### PR TITLE
Pumpup to auckland

### DIFF
--- a/.github/workflows/locale.yml
+++ b/.github/workflows/locale.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y osm2pgrouting \
+            gettext \
             postgresql-${PGVER}-postgis-${PGIS} \
             postgresql-${PGVER}-postgis-${PGIS}-scripts \
             postgresql-${PGVER}-pgrouting

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,27 +68,24 @@ set(OSMID_3 "11045827672")
 set(OSMID_4 "9452115611")
 set(OSMID_5 "11045833969")
 
-set(LAT1 "-1.422066")
-set(LON1 "-48.45665")
-
-
 # 3->1: routes for vehicles with penalty & no penalty must be different
 set(PLACE_1 "Auckland University of Technology")
 set(PLACE_2 "The Band Rotunda")
 set(PLACE_3 "Four Points by Sheraton")
 set(PLACE_4 "Sky tower")
-set(PLACE_5 "Emily place Reserve")
+set(PLACE_5 "Emily Place Reserve")
 
 
+# Example reference point (e.g., near Emily Place Reserve)
+set(CH7_PLACE_1 ${PLACE_5})
+set(CH7_OSMID_1 ${OSMID_5})
 set(POINT1_LAT "-36.8471438")
 set(POINT1_LON "174.7710042")
+
+# Example reference point (e.g., near Auckland University of Technology)
 set(POINT2_LAT "-36.8524328")
 set(POINT2_LON "174.766749")
-
-# by chapters
-set(CH7_PLACE_1 ${PLACE_5})
 set(CH7_PLACE_2 ${PLACE_1})
-set(CH7_OSMID_1 ${OSMID_5})
 set(CH7_OSMID_2 ${OSMID_1})
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,13 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 #---------------------------------------------
 # Setting the version number
 #---------------------------------------------
-set(PGR_WORKSHOP_CITY "Belém")
+set(PGR_WORKSHOP_CITY "Auckland")
 set(WORKSHOP_AREA "FOSS4G ${PGR_WORKSHOP_CITY}")
-set(COPYRIGHT "2010-2024 pgRouting Developers")
+set(COPYRIGHT "2010-2025 pgRouting Developers")
 set(PGR_WORKSHOP_VERSION_MAJOR "3")
-set(PGR_WORKSHOP_VERSION_MINOR "0")
-set(PGR_WORKSHOP_VERSION_PATCH "1")
-set(PGR_WORKSHOP_VERSION_DEV "")
+set(PGR_WORKSHOP_VERSION_MINOR "1")
+set(PGR_WORKSHOP_VERSION_PATCH "0")
+set(PGR_WORKSHOP_VERSION_DEV "-dev")
 set(PGR_WORKSHOP_VERSION "${PGR_WORKSHOP_VERSION_MAJOR}.${PGR_WORKSHOP_VERSION_MINOR}")
 set(PGR_WORKSHOP_RELEASE "${PGR_WORKSHOP_VERSION_MAJOR}.${PGR_WORKSHOP_VERSION_MINOR}.${PGR_WORKSHOP_VERSION_PATCH}${PGR_WORKSHOP_VERSION_DEV}")
 set(PGR_WORKSHOP_NAME "pgRouting workshop")
@@ -45,45 +45,45 @@ option(PGR_WORKSHOP_VERBOSE_DEBUG
 #---------------------------------------------
 # CONFIGURATION
 #---------------------------------------------
-set(PGR_WORKSHOP_CITY_FILE "BELEM_BR")
+set(PGR_WORKSHOP_CITY_FILE "auckland_NZ")
 
 # https://github.com/OSGeo/OSGeoLive/blob/master/bin/install_osm.sh
 # around line 117
-set(PGR_WORKSHOP_CITY_BBOX "-48.52,-1.49,-48.4,-1.36")
+set(PGR_WORKSHOP_CITY_BBOX "-36.8798,174.8,-36.8344,174.72")
 
 # Make it smaller
-set(PGR_WORKSHOP_LITTLE_NET_BBOX "-48.52,-1.46,-48.45,-1.41")
+set(PGR_WORKSHOP_LITTLE_NET_BBOX "174.775,-36.855,174.76,-36.84")
 
 # Use git blame to get the date when the line was changed
-set(PGR_WORKSHOP_DOWNLOAD_DIR "workshop-2024")
-set(DATE_OF_DATA "Sep 2024")
+set(PGR_WORKSHOP_DOWNLOAD_DIR "workshop-2025")
+set(DATE_OF_DATA "Jun 2025")
 
 if (WORKSHOP_DEBUG)
   message(STATUS "WORKSHOP_CITY_FILE=${WORKSHOP_CITY_FILE}")
 endif()
 
-set(OSMID_1 "10982869752")
-set(OSMID_2 "11818739588")
-set(OSMID_3 "491465035")
-set(OSMID_4 "1069202329")
-set(OSMID_5 "5661895682")
+set(OSMID_1 "9451619540")
+set(OSMID_2 "60662678")
+set(OSMID_3 "11045827672")
+set(OSMID_4 "9452115611")
+set(OSMID_5 "11045833969")
 
 set(LAT1 "-1.422066")
 set(LON1 "-48.45665")
 
 
 # 3->1: routes for vehicles with penalty & no penalty must be different
-set(PLACE_1 "Hangar Convention Center")
-set(PLACE_2 "Instituto Federal do Pará, Campus Belém")
-set(PLACE_3 "Palacete Bolonha")
-set(PLACE_4 "Forte do Castelo")
-set(PLACE_5 "Estação das Docas")
+set(PLACE_1 "Auckland University of Technology")
+set(PLACE_2 "The Band Rotunda")
+set(PLACE_3 "Four Points by Sheraton")
+set(PLACE_4 "Sky tower")
+set(PLACE_5 "Emily place Reserve")
 
 
-set(POINT1_LAT "-1.455829")
-set(POINT1_LON "-48.446044")
-set(POINT2_LAT "-1.453448")
-set(POINT2_LON "-48.447142")
+set(POINT1_LAT "-36.8471438")
+set(POINT1_LON "174.7710042")
+set(POINT2_LAT "-36.8524328")
+set(POINT2_LON "174.766749")
 
 # by chapters
 set(CH7_PLACE_1 ${PLACE_5})

--- a/docs/basic/graphs.rst
+++ b/docs/basic/graphs.rst
@@ -73,7 +73,7 @@ undirected graph is a set of vertices that are all reachable from each other.
    OR EMTPY SET
 
 Description of the function can be found in `pgr_extractVertices
-<https://docs.pgrouting.org/latest/en/pgr_connectedComponents.html>`__
+<https://docs.pgrouting.org/latest/en/pgr_extractVertices.html>`__
 
 Exercise 1: Create a vertices table
 -------------------------------------------------------------------------------

--- a/docs/basic/graphs.rst
+++ b/docs/basic/graphs.rst
@@ -59,9 +59,8 @@ The description of the graphs:
 pgr_extractVertices
 ================================================================================
 
-``pgr_extractVertices`` compute the connected components of an undirected
-graph using a Depth First Search approach. A connected component of an
-undirected graph is a set of vertices that are all reachable from each other.
+``pgr_extractVertices`` extracts the vertices (nodes) from an edge table and
+reports per-vertex attributes such as degree
 
 .. rubric:: Signature summary
 

--- a/docs/scripts/basic/data/CMakeLists.txt
+++ b/docs/scripts/basic/data/CMakeLists.txt
@@ -15,7 +15,6 @@ endforeach()
 add_custom_command(
   OUTPUT data.txt
   COMMAND bash data.sh > data.txt
-  DEPENDS data.sh
   )
 
 add_custom_target(basic_data_scripts

--- a/docs/scripts/basic/graphs/CMakeLists.txt
+++ b/docs/scripts/basic/graphs/CMakeLists.txt
@@ -45,5 +45,4 @@ add_custom_command(
 
   COMMAND psql -d city_routing -f graphs.sql
   COMMENT "running graphs scripts"
-  DEPENDS graphs.sql
 )

--- a/docs/scripts/basic/pedestrian/CMakeLists.txt
+++ b/docs/scripts/basic/pedestrian/CMakeLists.txt
@@ -28,6 +28,5 @@ add_custom_command(
   COMMAND psql -d city_routing -f pedestrian.sql
   COMMAND psql -d city_routing -f images.sql
   COMMENT "running pedestrian scripts"
-  DEPENDS pedestrian.sql
-  )
+)
 

--- a/docs/scripts/basic/plpgsql_function/CMakeLists.txt
+++ b/docs/scripts/basic/plpgsql_function/CMakeLists.txt
@@ -43,5 +43,4 @@ add_custom_command(
     warnings.txt
   COMMAND psql -d city_routing -f plpgsql_function.sql 2> warnings.txt
   COMMENT "running plpgsql_function scripts"
-  DEPENDS plpgsql_function.sql
   )

--- a/docs/scripts/basic/sql_function/CMakeLists.txt
+++ b/docs/scripts/basic/sql_function/CMakeLists.txt
@@ -28,5 +28,4 @@ add_custom_command(
   COMMAND psql -d city_routing -f sql_function.sql
   COMMAND psql -d city_routing -f images.sql
   COMMENT "running sql function scripts"
-  DEPENDS sql_function.sql
   )

--- a/docs/scripts/basic/vehicles/CMakeLists.txt
+++ b/docs/scripts/basic/vehicles/CMakeLists.txt
@@ -27,7 +27,7 @@ add_custom_command(
     section-6.2.2-2.txt
     section-6.6.txt
 
- COMMAND psql -d city_routing -f vehicles.sql
- COMMAND psql -d city_routing -f images.sql
- COMMENT "running vehicles scripts"
- DEPENDS vehicles.sql)
+  COMMAND psql -d city_routing -f vehicles.sql
+  COMMAND psql -d city_routing -f images.sql
+  COMMENT "running vehicles scripts"
+)

--- a/docs/scripts/un_sdg/sdg11/CMakeLists.txt
+++ b/docs/scripts/un_sdg/sdg11/CMakeLists.txt
@@ -51,5 +51,4 @@ add_custom_command(
     exercise_10.txt
   COMMAND psql -d bangladesh -f all_exercises_sdg11.sql
   COMMENT "running sdg11 scripts"
-  DEPENDS all_exercises_sdg11.sql
-  )
+)

--- a/docs/scripts/un_sdg/sdg3/CMakeLists.txt
+++ b/docs/scripts/un_sdg/sdg3/CMakeLists.txt
@@ -67,5 +67,4 @@ add_custom_command(
     exercise_20.txt
   COMMAND psql -d mumbai -f all_exercises_sdg3.sql
   COMMENT "running chapter sdg3 scripts"
-  DEPENDS all_exercises_sdg3.sql
-  )
+)

--- a/docs/scripts/un_sdg/sdg7/CMakeLists.txt
+++ b/docs/scripts/un_sdg/sdg7/CMakeLists.txt
@@ -33,5 +33,4 @@ add_custom_command(
     exercise_12.txt
   COMMAND psql -d mumbai -f all_exercises_sdg7.sql
   COMMENT "running chapter sdg7 scripts"
-  DEPENDS all_exercises_sdg7.sql
-  )
+)

--- a/locale/en/LC_MESSAGES/basic/data.po
+++ b/locale/en/LC_MESSAGES/basic/data.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:44+0000\n"
+"POT-Creation-Date: 2025-09-30 17:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: ../../build/docs/basic/data.rst:12
 msgid "Prepare Data"
@@ -51,8 +51,8 @@ msgstr ""
 #: ../../build/docs/basic/data.rst:30
 msgid ""
 "These requirements are met on OSGeoLive. When the required software is "
-"installed, open a terminal window by pressing :code:`ctrl-alt-t` and "
-"follow the instructions."
+"installed, open a terminal window by pressing :code:`ctrl-alt-t` and follow "
+"the instructions."
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:34
@@ -63,8 +63,8 @@ msgstr ""
 
 #: ../../build/docs/basic/data.rst:37
 msgid ""
-"If OSGeoLive is not being used, please refer to the chapter's appendix to"
-" set up the user ``user``."
+"If OSGeoLive is not being used, please refer to the chapter's appendix to "
+"set up the user ``user``."
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:41
@@ -73,8 +73,8 @@ msgstr ""
 
 #: ../../build/docs/basic/data.rst:43
 msgid ""
-"Depending on the postgres configuration :code:`-U <user>` is needed on "
-":code:`psql` commands"
+"Depending on the postgres configuration :code:`-U <user>` is needed on :code:"
+"`psql` commands"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:51
@@ -87,9 +87,9 @@ msgstr ""
 
 #: ../../build/docs/basic/data.rst:58
 msgid ""
-"The pgRouting workshop will make use of OpenStreetMap data, which is "
-"already available on `OSGeoLive <https://live.osgeo.org>`_. This workshop"
-" will use the ``Belém`` city data and is a snapshot of Sep 2024."
+"The pgRouting workshop will make use of OpenStreetMap data, which is already "
+"available on `OSGeoLive <https://live.osgeo.org>`_. This workshop will use "
+"the ``Auckland`` city data and is a snapshot of Jun 2025."
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:63
@@ -101,7 +101,7 @@ msgid "Option 1) When using OSGeoLive"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:68
-msgid "OSGeoLive comes with OSM data from the city of Belém."
+msgid "OSGeoLive comes with OSM data from the city of Auckland."
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:76
@@ -118,15 +118,15 @@ msgstr ""
 
 #: ../../build/docs/basic/data.rst:88
 msgid ""
-"The following downloads the latest OSM data on using the same area. Using"
-" this data in the workshop can generate variations in the results, due to"
-" changes since Sep 2024."
+"The following downloads the latest OSM data on using the same area. Using "
+"this data in the workshop can generate variations in the results, due to "
+"changes since Jun 2025."
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:98
 msgid ""
-"More information about how to download OpenStreetMap data can be found in"
-" https://wiki.openstreetmap.org/wiki/Downloading_data"
+"More information about how to download OpenStreetMap data can be found in "
+"https://wiki.openstreetmap.org/wiki/Downloading_data"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:101
@@ -141,10 +141,10 @@ msgstr ""
 
 #: ../../build/docs/basic/data.rst:108
 msgid ""
-"The next step is to run ``osm2pgrouting`` converter, which is a command "
-"line tool that inserts the data in the database, \"ready\" to be used "
-"with pgRouting. Additional information about ``osm2pgrouting`` can be "
-"found at the :doc:`../appendix/appendix-3`"
+"The next step is to run ``osm2pgrouting`` converter, which is a command line "
+"tool that inserts the data in the database, \"ready\" to be used with "
+"pgRouting. Additional information about ``osm2pgrouting`` can be found at "
+"the :doc:`../appendix/appendix-3`"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:112
@@ -156,7 +156,7 @@ msgid "the osm2pgrouting default ``mapconfig.xml`` configuration file is used"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:115
-msgid "and the ``~/Desktop/workshop/BELEM_BR.osm`` data"
+msgid "and the ``~/Desktop/workshop/auckland_NZ.osm`` data"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:116
@@ -196,4 +196,3 @@ msgid ""
 "OSGeoLive's account name on the database is ``user``. To easily use the "
 "workshop when not using OSGeoLive this extra steps are needed:"
 msgstr ""
-

--- a/locale/en/LC_MESSAGES/basic/graphs.po
+++ b/locale/en/LC_MESSAGES/basic/graphs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-10 17:09+0000\n"
+"POT-Creation-Date: 2025-09-30 17:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: ../../build/docs/basic/graphs.rst:12
 msgid "Graph views"
@@ -30,9 +30,8 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:20
 msgid ""
-"Different application require different graphs. This chapter covers how "
-"to discard disconnected segments and different approaches to create "
-"graphs."
+"Different application require different graphs. This chapter covers how to "
+"discard disconnected segments and different approaches to create graphs."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:24
@@ -42,10 +41,9 @@ msgstr ""
 #: ../../build/docs/basic/graphs.rst:26
 msgid ""
 "In this chapter there are three graph requirements. It consists on three "
-"graphs based on a **fully connected** graph derived from ``ways``: two "
-"for different types of vehicles and one for pedestrian, the source and "
-"the target in all of them are based on the ``source_osm`` and "
-"``target_osm``."
+"graphs based on a **fully connected** graph derived from ``ways``: two for "
+"different types of vehicles and one for pedestrian, the source and the "
+"target in all of them are based on the ``source_osm`` and ``target_osm``."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:31
@@ -57,11 +55,10 @@ msgid "Particular vehicle:"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:35
-msgid "Circulate on the whole Belém area."
+msgid "Circulate on the whole Auckland area."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:37
-#: ../../build/docs/basic/graphs.rst:46
+#: ../../build/docs/basic/graphs.rst:37 ../../build/docs/basic/graphs.rst:46
 msgid "Do not use `steps`, `footway`, `path`, `cycleway`."
 msgstr ""
 
@@ -78,7 +75,7 @@ msgid "Circulate on a smaller area:"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:45
-msgid "Bounding box: ``(-48.52,-1.46,-48.45,-1.41)``"
+msgid "Bounding box: ``(174.775,-36.855,174.76,-36.84)``"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:48
@@ -91,7 +88,7 @@ msgid "Pedestrians:"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:52
-msgid "Walk on the whole Belém area."
+msgid "Walk on the whole Auckland area."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:53
@@ -102,8 +99,7 @@ msgstr ""
 msgid "`motorways` and on `primary` segments."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:57
-#: ../../build/docs/basic/graphs.rst:488
+#: ../../build/docs/basic/graphs.rst:57 ../../build/docs/basic/graphs.rst:488
 msgid "The speed is ``2 mts/sec``."
 msgstr ""
 
@@ -113,35 +109,29 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:62
 msgid ""
-"``pgr_extractVertices`` compute the connected components of an undirected"
-" graph using a Depth First Search approach. A connected component of an "
-"undirected graph is a set of vertices that are all reachable from each "
-"other."
+"``pgr_extractVertices`` compute the connected components of an undirected "
+"graph using a Depth First Search approach. A connected component of an "
+"undirected graph is a set of vertices that are all reachable from each other."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:67
-#: ../../build/docs/basic/graphs.rst:214
+#: ../../build/docs/basic/graphs.rst:67 ../../build/docs/basic/graphs.rst:214
 msgid "Signature summary"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:75
 msgid ""
-"Description of the function can be found in `pgr_extractVertices "
-"<https://docs.pgrouting.org/latest/en/pgr_connectedComponents.html>`__"
+"Description of the function can be found in `pgr_extractVertices <https://"
+"docs.pgrouting.org/latest/en/pgr_connectedComponents.html>`__"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:79
 msgid "Exercise 1: Create a vertices table"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:82
-#: ../../build/docs/basic/graphs.rst:130
-#: ../../build/docs/basic/graphs.rst:230
-#: ../../build/docs/basic/graphs.rst:278
-#: ../../build/docs/basic/graphs.rst:355
-#: ../../build/docs/basic/graphs.rst:426
-#: ../../build/docs/basic/graphs.rst:484
-#: ../../build/docs/basic/graphs.rst:548
+#: ../../build/docs/basic/graphs.rst:82 ../../build/docs/basic/graphs.rst:130
+#: ../../build/docs/basic/graphs.rst:230 ../../build/docs/basic/graphs.rst:278
+#: ../../build/docs/basic/graphs.rst:355 ../../build/docs/basic/graphs.rst:426
+#: ../../build/docs/basic/graphs.rst:484 ../../build/docs/basic/graphs.rst:548
 msgid "Problem"
 msgstr ""
 
@@ -149,14 +139,10 @@ msgstr ""
 msgid "Create the vertices table corresponding to the edges in ``ways``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:86
-#: ../../build/docs/basic/graphs.rst:134
-#: ../../build/docs/basic/graphs.rst:234
-#: ../../build/docs/basic/graphs.rst:287
-#: ../../build/docs/basic/graphs.rst:369
-#: ../../build/docs/basic/graphs.rst:435
-#: ../../build/docs/basic/graphs.rst:499
-#: ../../build/docs/basic/graphs.rst:567
+#: ../../build/docs/basic/graphs.rst:86 ../../build/docs/basic/graphs.rst:134
+#: ../../build/docs/basic/graphs.rst:234 ../../build/docs/basic/graphs.rst:287
+#: ../../build/docs/basic/graphs.rst:369 ../../build/docs/basic/graphs.rst:435
+#: ../../build/docs/basic/graphs.rst:499 ../../build/docs/basic/graphs.rst:567
 msgid "Solution"
 msgstr ""
 
@@ -175,7 +161,8 @@ msgid ""
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:91
-msgid "From the requirements, the graph is going to be based on OSM identifiers."
+msgid ""
+"From the requirements, the graph is going to be based on OSM identifiers."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:104
@@ -200,8 +187,8 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:145
 msgid ""
-"Update the ``geom`` columns based on the ``source_osm`` column from "
-"``ways`` table."
+"Update the ``geom`` columns based on the ``source_osm`` column from ``ways`` "
+"table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:147
@@ -210,14 +197,14 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:158
 msgid ""
-"Not expecting to be done due to the fact that some vertices are only dead"
-" ends."
+"Not expecting to be done due to the fact that some vertices are only dead "
+"ends."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:169
 msgid ""
-"Update the ``geom`` columns based on the ``target_osm`` column from "
-"``ways`` table."
+"Update the ``geom`` columns based on the ``target_osm`` column from ``ways`` "
+"table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:171
@@ -226,8 +213,8 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:182
 msgid ""
-"Expecting to be done, that is the geometry column should not have a "
-"``NULL`` value."
+"Expecting to be done, that is the geometry column should not have a ``NULL`` "
+"value."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:194
@@ -241,9 +228,9 @@ msgstr ""
 #: ../../build/docs/basic/graphs.rst:209
 msgid ""
 "``pgr_connectedComponents`` compute the connected components of an "
-"undirected graph using a Depth First Search approach. A connected "
-"component of an undirected graph is a set of vertices that are all "
-"reachable from each other."
+"undirected graph using a Depth First Search approach. A connected component "
+"of an undirected graph is a set of vertices that are all reachable from each "
+"other."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:222
@@ -290,28 +277,23 @@ msgstr ""
 msgid "Answer the following questions:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:281
-#: ../../build/docs/basic/graphs.rst:288
+#: ../../build/docs/basic/graphs.rst:281 ../../build/docs/basic/graphs.rst:288
 msgid "How many components are in the vertices table?"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:282
-#: ../../build/docs/basic/graphs.rst:301
+#: ../../build/docs/basic/graphs.rst:282 ../../build/docs/basic/graphs.rst:301
 msgid "How many components are in the edges table?"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:283
-#: ../../build/docs/basic/graphs.rst:314
+#: ../../build/docs/basic/graphs.rst:283 ../../build/docs/basic/graphs.rst:314
 msgid "List the 10 components with more edges."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:284
-#: ../../build/docs/basic/graphs.rst:328
+#: ../../build/docs/basic/graphs.rst:284 ../../build/docs/basic/graphs.rst:328
 msgid "Get the component with the maximum number of edges."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:290
-#: ../../build/docs/basic/graphs.rst:303
+#: ../../build/docs/basic/graphs.rst:290 ../../build/docs/basic/graphs.rst:303
 msgid "Count the distinct components."
 msgstr ""
 
@@ -363,8 +345,7 @@ msgstr ""
 msgid "Exclude `steps`, `footway`, `path`, `cycleway` segments."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:360
-#: ../../build/docs/basic/graphs.rst:491
+#: ../../build/docs/basic/graphs.rst:360 ../../build/docs/basic/graphs.rst:491
 msgid "Data needed in the view for further processing."
 msgstr ""
 
@@ -380,13 +361,11 @@ msgstr ""
 msgid "`the_geom` The geometry rename to ``geom``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:366
-#: ../../build/docs/basic/graphs.rst:496
+#: ../../build/docs/basic/graphs.rst:366 ../../build/docs/basic/graphs.rst:496
 msgid "Verify the number of edges was reduced."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:370
-#: ../../build/docs/basic/graphs.rst:436
+#: ../../build/docs/basic/graphs.rst:370 ../../build/docs/basic/graphs.rst:436
 #: ../../build/docs/basic/graphs.rst:500
 msgid "Creating the view:"
 msgstr ""
@@ -403,12 +382,13 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:375
 msgid ""
-"The `source` and `target` requirements for the function are to be with "
-"OSM identifiers. (line **14**)"
+"The `source` and `target` requirements for the function are to be with OSM "
+"identifiers. (line **14**)"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:377
-msgid "The ``cost`` and ``reverse_cost`` are in terms of seconds. (line **15**)"
+msgid ""
+"The ``cost`` and ``reverse_cost`` are in terms of seconds. (line **15**)"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:378
@@ -452,7 +432,7 @@ msgstr ""
 #: ../../build/docs/basic/graphs.rst:429
 msgid ""
 "The taxi can only circulate inside this Bounding Box: "
-"``(-48.52,-1.46,-48.45,-1.41)``"
+"``(174.775,-36.855,174.76,-36.84)``"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:430
@@ -467,28 +447,26 @@ msgstr ""
 #: ../../build/docs/basic/graphs.rst:438
 #, python-format
 msgid ""
-"Adjust the taxi's ``cost`` and ``reverse_cost`` to be 10% slower than of "
-"the particular vehicle. (line **7**)"
+"Adjust the taxi's ``cost`` and ``reverse_cost`` to be 10% slower than of the "
+"particular vehicle. (line **7**)"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:440
 msgid ""
-"The graph for the taxi is a subset of the ``vehicle_net`` graph. (line "
-"**9**)"
+"The graph for the taxi is a subset of the ``vehicle_net`` graph. (line **9**)"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:441
 msgid ""
 "Can only circulate inside the bounding box: "
-"``(-48.52,-1.46,-48.45,-1.41)``. (line **10**)"
+"``(174.775,-36.855,174.76,-36.84)``. (line **10**)"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:455
 msgid "Count the rows on ``taxi_net``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:466
-#: ../../build/docs/basic/graphs.rst:529
+#: ../../build/docs/basic/graphs.rst:466 ../../build/docs/basic/graphs.rst:529
 msgid "Get the description."
 msgstr ""
 
@@ -502,8 +480,8 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:485
 msgid ""
-"Create a materialized view with minimal amount of information for "
-"processing pedestrians."
+"Create a materialized view with minimal amount of information for processing "
+"pedestrians."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:486
@@ -530,8 +508,8 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:504
 msgid ""
-"The ``cost`` and ``reverse_cost`` are in terms of seconds with speed of "
-"``2 mts/sec``. (line **7**)"
+"The ``cost`` and ``reverse_cost`` are in terms of seconds with speed of ``2 "
+"mts/sec``. (line **7**)"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:505
@@ -580,8 +558,8 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:560
 msgid ""
-"Only show the following results, as the other columns are to be ignored "
-"on the function."
+"Only show the following results, as the other columns are to be ignored on "
+"the function."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:562
@@ -617,7 +595,8 @@ msgid "``vehicle_net`` is used."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:576
-msgid "Selection of the columns with the corresponding names are on line **1**."
+msgid ""
+"Selection of the columns with the corresponding names are on line **1**."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:577
@@ -630,8 +609,7 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:581
 msgid ""
-"The OSM identifiers of the departure and destination are used. (line "
-"**4**)"
+"The OSM identifiers of the departure and destination are used. (line **4**)"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:594
@@ -659,4 +637,3 @@ msgstr ""
 #: ../../build/docs/basic/graphs.rst:613
 msgid "The results give a different route than of the vehicles."
 msgstr ""
-

--- a/locale/en/LC_MESSAGES/basic/graphs.po
+++ b/locale/en/LC_MESSAGES/basic/graphs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 17:36+0000\n"
+"POT-Creation-Date: 2025-09-30 18:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -121,7 +121,7 @@ msgstr ""
 #: ../../build/docs/basic/graphs.rst:75
 msgid ""
 "Description of the function can be found in `pgr_extractVertices <https://"
-"docs.pgrouting.org/latest/en/pgr_connectedComponents.html>`__"
+"docs.pgrouting.org/latest/en/pgr_extractVertices.html>`__"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:79

--- a/locale/en/LC_MESSAGES/basic/graphs.po
+++ b/locale/en/LC_MESSAGES/basic/graphs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 18:24+0000\n"
+"POT-Creation-Date: 2025-09-30 18:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -99,7 +99,7 @@ msgstr ""
 msgid "`motorways` and on `primary` segments."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:57 ../../build/docs/basic/graphs.rst:488
+#: ../../build/docs/basic/graphs.rst:57 ../../build/docs/basic/graphs.rst:487
 msgid "The speed is ``2 mts/sec``."
 msgstr ""
 
@@ -109,123 +109,122 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:62
 msgid ""
-"``pgr_extractVertices`` compute the connected components of an undirected "
-"graph using a Depth First Search approach. A connected component of an "
-"undirected graph is a set of vertices that are all reachable from each other."
+"``pgr_extractVertices`` extracts the vertices (nodes) from an edge table and "
+"reports per-vertex attributes such as degree"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:67 ../../build/docs/basic/graphs.rst:214
+#: ../../build/docs/basic/graphs.rst:66 ../../build/docs/basic/graphs.rst:213
 msgid "Signature summary"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:75
+#: ../../build/docs/basic/graphs.rst:74
 msgid ""
 "Description of the function can be found in `pgr_extractVertices <https://"
 "docs.pgrouting.org/latest/en/pgr_extractVertices.html>`__"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:79
+#: ../../build/docs/basic/graphs.rst:78
 msgid "Exercise 1: Create a vertices table"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:82 ../../build/docs/basic/graphs.rst:130
-#: ../../build/docs/basic/graphs.rst:230 ../../build/docs/basic/graphs.rst:278
-#: ../../build/docs/basic/graphs.rst:355 ../../build/docs/basic/graphs.rst:426
-#: ../../build/docs/basic/graphs.rst:484 ../../build/docs/basic/graphs.rst:548
+#: ../../build/docs/basic/graphs.rst:81 ../../build/docs/basic/graphs.rst:129
+#: ../../build/docs/basic/graphs.rst:229 ../../build/docs/basic/graphs.rst:277
+#: ../../build/docs/basic/graphs.rst:354 ../../build/docs/basic/graphs.rst:425
+#: ../../build/docs/basic/graphs.rst:483 ../../build/docs/basic/graphs.rst:547
 msgid "Problem"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:83
+#: ../../build/docs/basic/graphs.rst:82
 msgid "Create the vertices table corresponding to the edges in ``ways``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:86 ../../build/docs/basic/graphs.rst:134
-#: ../../build/docs/basic/graphs.rst:234 ../../build/docs/basic/graphs.rst:287
-#: ../../build/docs/basic/graphs.rst:369 ../../build/docs/basic/graphs.rst:435
-#: ../../build/docs/basic/graphs.rst:499 ../../build/docs/basic/graphs.rst:567
+#: ../../build/docs/basic/graphs.rst:85 ../../build/docs/basic/graphs.rst:133
+#: ../../build/docs/basic/graphs.rst:233 ../../build/docs/basic/graphs.rst:286
+#: ../../build/docs/basic/graphs.rst:368 ../../build/docs/basic/graphs.rst:434
+#: ../../build/docs/basic/graphs.rst:498 ../../build/docs/basic/graphs.rst:566
 msgid "Solution"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:87
+#: ../../build/docs/basic/graphs.rst:86
 msgid "A graph consists of a set of vertices and a set of edges."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:88
+#: ../../build/docs/basic/graphs.rst:87
 msgid "In this case, the ``ways`` table is a set of edges."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:89
+#: ../../build/docs/basic/graphs.rst:88
 msgid ""
 "In order to make use of all the graph functions from pgRouting, it is "
 "required have the set of vertices defined."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:91
+#: ../../build/docs/basic/graphs.rst:90
 msgid ""
 "From the requirements, the graph is going to be based on OSM identifiers."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:104
+#: ../../build/docs/basic/graphs.rst:103
 msgid "Reviewing the description of the vertices table"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:114
+#: ../../build/docs/basic/graphs.rst:113
 msgid "Inspecting the information on the vertices table"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:127
+#: ../../build/docs/basic/graphs.rst:126
 msgid "Exercise 2: Fill up other columns in the vertices table"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:131
+#: ../../build/docs/basic/graphs.rst:130
 msgid "Fill up geometry information on the vertices table."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:135
+#: ../../build/docs/basic/graphs.rst:134
 msgid "Count the number of rows that need to be filled up."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:145
+#: ../../build/docs/basic/graphs.rst:144
 msgid ""
 "Update the ``geom`` columns based on the ``source_osm`` column from ``ways`` "
 "table."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:147
+#: ../../build/docs/basic/graphs.rst:146
 msgid "Use the start point of the geometry."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:158
+#: ../../build/docs/basic/graphs.rst:157
 msgid ""
 "Not expecting to be done due to the fact that some vertices are only dead "
 "ends."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:169
+#: ../../build/docs/basic/graphs.rst:168
 msgid ""
 "Update the ``geom`` columns based on the ``target_osm`` column from ``ways`` "
 "table."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:171
+#: ../../build/docs/basic/graphs.rst:170
 msgid "Use the end point of the geometry."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:182
+#: ../../build/docs/basic/graphs.rst:181
 msgid ""
 "Expecting to be done, that is the geometry column should not have a ``NULL`` "
 "value."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:194
+#: ../../build/docs/basic/graphs.rst:193
 msgid "Update the ``x`` and ``y`` columns based on the ``geom`` column."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:207
+#: ../../build/docs/basic/graphs.rst:206
 msgid "pgr_connectedComponents"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:209
+#: ../../build/docs/basic/graphs.rst:208
 msgid ""
 "``pgr_connectedComponents`` compute the connected components of an "
 "undirected graph using a Depth First Search approach. A connected component "
@@ -233,407 +232,407 @@ msgid ""
 "other."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:222
+#: ../../build/docs/basic/graphs.rst:221
 msgid ""
 "Description of the function can be found in `pgr_connectedComponents "
 "<https://docs.pgrouting.org/latest/en/pgr_connectedComponents.html>`__"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:227
+#: ../../build/docs/basic/graphs.rst:226
 msgid "Exercise 3: Set components on edges and vertices tables"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:231
+#: ../../build/docs/basic/graphs.rst:230
 msgid "Get the information about the graph components."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:235
+#: ../../build/docs/basic/graphs.rst:234
 msgid "Create additional columns on the edges and vertices tables."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:246
+#: ../../build/docs/basic/graphs.rst:245
 msgid "Use the ``pgr_connectedComponents`` to fill up the vertices table."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:248
+#: ../../build/docs/basic/graphs.rst:247
 msgid ""
 "Use the results to store the component numbers on the vertices table. "
 "(**line 1**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:250
+#: ../../build/docs/basic/graphs.rst:249
 msgid "Use the OSM identifiers of the vertices. (**lines 4-5**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:262
+#: ../../build/docs/basic/graphs.rst:261
 msgid "Update the edges table with based on the component number of the vertex"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:275
+#: ../../build/docs/basic/graphs.rst:274
 msgid "Exercise 4: Inspect the components"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:279
+#: ../../build/docs/basic/graphs.rst:278
 msgid "Answer the following questions:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:281 ../../build/docs/basic/graphs.rst:288
+#: ../../build/docs/basic/graphs.rst:280 ../../build/docs/basic/graphs.rst:287
 msgid "How many components are in the vertices table?"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:282 ../../build/docs/basic/graphs.rst:301
+#: ../../build/docs/basic/graphs.rst:281 ../../build/docs/basic/graphs.rst:300
 msgid "How many components are in the edges table?"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:283 ../../build/docs/basic/graphs.rst:314
+#: ../../build/docs/basic/graphs.rst:282 ../../build/docs/basic/graphs.rst:313
 msgid "List the 10 components with more edges."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:284 ../../build/docs/basic/graphs.rst:328
+#: ../../build/docs/basic/graphs.rst:283 ../../build/docs/basic/graphs.rst:327
 msgid "Get the component with the maximum number of edges."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:290 ../../build/docs/basic/graphs.rst:303
+#: ../../build/docs/basic/graphs.rst:289 ../../build/docs/basic/graphs.rst:302
 msgid "Count the distinct components."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:316
+#: ../../build/docs/basic/graphs.rst:315
 msgid "Count number of rows grouped by component. (**line 1**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:317
+#: ../../build/docs/basic/graphs.rst:316
 msgid "Inverse order to display the top 10. (**line 2**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:330
+#: ../../build/docs/basic/graphs.rst:329
 msgid "Use the query from last question to get the maximum count"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:331
+#: ../../build/docs/basic/graphs.rst:330
 msgid "Get the component that matches the maximum value."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:345
+#: ../../build/docs/basic/graphs.rst:344
 msgid "Preparing the graphs"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:348
+#: ../../build/docs/basic/graphs.rst:347
 msgid "Exercise 5: Creating a view for routing"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:350
+#: ../../build/docs/basic/graphs.rst:349
 msgid "View of roads for vehicles"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:356
+#: ../../build/docs/basic/graphs.rst:355
 msgid ""
 "Create a view with minimal amount of information for processing the "
 "particular vehicles."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:357
+#: ../../build/docs/basic/graphs.rst:356
 msgid "Use the OSM identifiers on the vertices."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:358
+#: ../../build/docs/basic/graphs.rst:357
 msgid ""
 "Routing `cost` and `reverse_cost` in terms of seconds for routing "
 "calculations."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:359
+#: ../../build/docs/basic/graphs.rst:358
 msgid "Exclude `steps`, `footway`, `path`, `cycleway` segments."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:360 ../../build/docs/basic/graphs.rst:491
+#: ../../build/docs/basic/graphs.rst:359 ../../build/docs/basic/graphs.rst:490
 msgid "Data needed in the view for further processing."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:362
+#: ../../build/docs/basic/graphs.rst:361
 msgid "`name` The name of the segment."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:363
+#: ../../build/docs/basic/graphs.rst:362
 msgid "`length_m` The length in meters rename to ``length``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:364
+#: ../../build/docs/basic/graphs.rst:363
 msgid "`the_geom` The geometry rename to ``geom``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:366 ../../build/docs/basic/graphs.rst:496
+#: ../../build/docs/basic/graphs.rst:365 ../../build/docs/basic/graphs.rst:495
 msgid "Verify the number of edges was reduced."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:370 ../../build/docs/basic/graphs.rst:436
-#: ../../build/docs/basic/graphs.rst:500
+#: ../../build/docs/basic/graphs.rst:369 ../../build/docs/basic/graphs.rst:435
+#: ../../build/docs/basic/graphs.rst:499
 msgid "Creating the view:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:372
+#: ../../build/docs/basic/graphs.rst:371
 msgid ""
 "If you need to reconstruct the view, first drop it using the command on "
 "**line 1**."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:374
+#: ../../build/docs/basic/graphs.rst:373
 msgid "Get the component with maximum number of edges (**lines 6-10**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:375
+#: ../../build/docs/basic/graphs.rst:374
 msgid ""
 "The `source` and `target` requirements for the function are to be with OSM "
 "identifiers. (line **14**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:377
+#: ../../build/docs/basic/graphs.rst:376
 msgid ""
 "The ``cost`` and ``reverse_cost`` are in terms of seconds. (line **15**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:378
+#: ../../build/docs/basic/graphs.rst:377
 msgid ""
 "The additional parameters ``length_m`` and ``the_geom`` are renamed, "
 "``name`` is also included. (line **16**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:380
+#: ../../build/docs/basic/graphs.rst:379
 msgid "``JOIN`` with the `configuration`:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:382
+#: ../../build/docs/basic/graphs.rst:381
 msgid "Exclude `steps`, `footway`, `path`, `cycleway`. (line **18**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:395
+#: ../../build/docs/basic/graphs.rst:394
 msgid "Verification:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:397
+#: ../../build/docs/basic/graphs.rst:396
 msgid "Count the rows on the original ``ways`` and on ``vehicle_net``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:407
+#: ../../build/docs/basic/graphs.rst:406
 msgid "Get the description of the view"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:419
+#: ../../build/docs/basic/graphs.rst:418
 msgid "Exercise 6: Limiting the road network within an area"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:421
+#: ../../build/docs/basic/graphs.rst:420
 msgid "View of smaller set of roads for vehicles"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:427
+#: ../../build/docs/basic/graphs.rst:426
 msgid "Create a view ``taxi_net`` for the `taxi`:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:429
+#: ../../build/docs/basic/graphs.rst:428
 msgid ""
 "The taxi can only circulate inside this Bounding Box: "
 "``(174.775,-36.855,174.76,-36.84)``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:430
+#: ../../build/docs/basic/graphs.rst:429
 #, python-format
 msgid "The taxi speed is 10% slower than the particular vehicle."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:432
+#: ../../build/docs/basic/graphs.rst:431
 msgid "Verify the reduced number of road segments."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:438
+#: ../../build/docs/basic/graphs.rst:437
 #, python-format
 msgid ""
 "Adjust the taxi's ``cost`` and ``reverse_cost`` to be 10% slower than of the "
 "particular vehicle. (line **7**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:440
+#: ../../build/docs/basic/graphs.rst:439
 msgid ""
 "The graph for the taxi is a subset of the ``vehicle_net`` graph. (line **9**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:441
+#: ../../build/docs/basic/graphs.rst:440
 msgid ""
 "Can only circulate inside the bounding box: "
 "``(174.775,-36.855,174.76,-36.84)``. (line **10**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:455
+#: ../../build/docs/basic/graphs.rst:454
 msgid "Count the rows on ``taxi_net``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:466 ../../build/docs/basic/graphs.rst:529
+#: ../../build/docs/basic/graphs.rst:465 ../../build/docs/basic/graphs.rst:528
 msgid "Get the description."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:477
+#: ../../build/docs/basic/graphs.rst:476
 msgid "Exercise 7: Creating a materialized view for routing pedestrians"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:479
+#: ../../build/docs/basic/graphs.rst:478
 msgid "View of roads for pedestrians"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:485
+#: ../../build/docs/basic/graphs.rst:484
 msgid ""
 "Create a materialized view with minimal amount of information for processing "
 "pedestrians."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:486
+#: ../../build/docs/basic/graphs.rst:485
 msgid ""
 "Routing `cost` and `reverse_cost` will be on seconds for routing "
 "calculations."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:490
+#: ../../build/docs/basic/graphs.rst:489
 msgid "Exclude `motorway` , `primary` and `secondary` segments."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:493
+#: ../../build/docs/basic/graphs.rst:492
 msgid "`length_m` The length in meters."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:494
+#: ../../build/docs/basic/graphs.rst:493
 msgid "`the_geom` The geometry."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:502
+#: ../../build/docs/basic/graphs.rst:501
 msgid "Similar to `Exercise 5: Creating a view for routing`_:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:504
+#: ../../build/docs/basic/graphs.rst:503
 msgid ""
 "The ``cost`` and ``reverse_cost`` are in terms of seconds with speed of ``2 "
 "mts/sec``. (line **7**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:505
+#: ../../build/docs/basic/graphs.rst:504
 msgid "Exclude `motorway`, `primary` and `secondary` . (line **11**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:518
+#: ../../build/docs/basic/graphs.rst:517
 msgid "Count the rows on the view ``walk_net``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:541
+#: ../../build/docs/basic/graphs.rst:540
 msgid "Exercise 8: Testing the views for routing"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:543
+#: ../../build/docs/basic/graphs.rst:542
 msgid "From the |ch7_place_1| to the |ch7_place_2|"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:549
+#: ../../build/docs/basic/graphs.rst:548
 msgid "Test the created views"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:551
+#: ../../build/docs/basic/graphs.rst:550
 msgid "In particular:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:553
+#: ../../build/docs/basic/graphs.rst:552
 msgid "From the |ch7_place_1| to the \"|ch7_place_2| using the OSM identifier"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:554
+#: ../../build/docs/basic/graphs.rst:553
 msgid "the views to be tested are:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:556
+#: ../../build/docs/basic/graphs.rst:555
 msgid "``vehicle_net``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:557
+#: ../../build/docs/basic/graphs.rst:556
 msgid "``taxi_net``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:558
+#: ../../build/docs/basic/graphs.rst:557
 msgid "``walk_net``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:560
+#: ../../build/docs/basic/graphs.rst:559
 msgid ""
 "Only show the following results, as the other columns are to be ignored on "
 "the function."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:562
+#: ../../build/docs/basic/graphs.rst:561
 msgid "``seq``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:563
+#: ../../build/docs/basic/graphs.rst:562
 msgid "``edge`` with the name ``id``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:564
+#: ../../build/docs/basic/graphs.rst:563
 msgid "``cost`` with the name: ``seconds``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:568
+#: ../../build/docs/basic/graphs.rst:567
 msgid "In general"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:570
+#: ../../build/docs/basic/graphs.rst:569
 msgid "The departure is |ch7_place_1| with OSM identifier |ch7_osmid_1|."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:571
+#: ../../build/docs/basic/graphs.rst:570
 msgid "The destination is |ch7_place_2| with OSM identifier |ch7_osmid_2|."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:573
+#: ../../build/docs/basic/graphs.rst:572
 msgid "For ``vehicle_net``:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:575
+#: ../../build/docs/basic/graphs.rst:574
 msgid "``vehicle_net`` is used."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:576
+#: ../../build/docs/basic/graphs.rst:575
 msgid ""
 "Selection of the columns with the corresponding names are on line **1**."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:577
+#: ../../build/docs/basic/graphs.rst:576
 msgid "The view is prepared with the column names that pgRouting use."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:579
+#: ../../build/docs/basic/graphs.rst:578
 msgid "There is no need to rename columns. (line **3**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:581
+#: ../../build/docs/basic/graphs.rst:580
 msgid ""
 "The OSM identifiers of the departure and destination are used. (line **4**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:594
+#: ../../build/docs/basic/graphs.rst:593
 msgid "For ``taxi_net``:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:596
+#: ../../build/docs/basic/graphs.rst:595
 msgid "Similar as the previous one but with ``taxi_net``. (line **3**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:597
+#: ../../build/docs/basic/graphs.rst:596
 msgid ""
 "The results give the same route as with ``vehicle_net`` but ``cost`` is "
 "higher."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:610
+#: ../../build/docs/basic/graphs.rst:609
 msgid "For ``walk_net``:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:612
+#: ../../build/docs/basic/graphs.rst:611
 msgid "Similar as the previous one but with ``walk_net``. (line **3**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:613
+#: ../../build/docs/basic/graphs.rst:612
 msgid "The results give a different route than of the vehicles."
 msgstr ""

--- a/locale/en/LC_MESSAGES/basic/pedestrian.po
+++ b/locale/en/LC_MESSAGES/basic/pedestrian.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-10 17:09+0000\n"
+"POT-Creation-Date: 2025-09-30 17:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: ../../build/docs/basic/pedestrian.rst:11
 msgid "Pedestrian Routing"
@@ -27,8 +27,8 @@ msgstr ""
 #: ../../build/docs/basic/pedestrian.rst:17
 msgid ""
 "**pgRouting** was first called *pgDijkstra*, because it implemented only "
-"shortest path search with *Dijkstra* algorithm. Later other functions "
-"were added and the library was renamed to pgRouting."
+"shortest path search with *Dijkstra* algorithm. Later other functions were "
+"added and the library was renamed to pgRouting."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:22
@@ -42,14 +42,14 @@ msgstr ""
 #: ../../build/docs/basic/pedestrian.rst:27
 msgid ""
 "Dijkstra algorithm was the first algorithm implemented in pgRouting. It "
-"doesn't require other attributes than the identifiers ``id``, ``source`` "
-"and ``target`` and the weights ``cost`` and ``reverse_cost``."
+"doesn't require other attributes than the identifiers ``id``, ``source`` and "
+"``target`` and the weights ``cost`` and ``reverse_cost``."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:31
 msgid ""
-"You can specify when to consider the graph as `directed "
-"<https://en.wikipedia.org/wiki/Directed_graph>`__ or undirected."
+"You can specify when to consider the graph as `directed <https://en."
+"wikipedia.org/wiki/Directed_graph>`__ or undirected."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:35
@@ -59,27 +59,28 @@ msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:47
 msgid ""
-"Description of the function can be found in `pgr_dijkstra "
-"<https://docs.pgrouting.org/latest/en/pgr_dijkstra.html>`__."
+"Description of the function can be found in `pgr_dijkstra <https://docs."
+"pgrouting.org/latest/en/pgr_dijkstra.html>`__."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:51
 msgid ""
-"Many pgRouting functions have ``sql::text`` as one of their arguments. "
-"While this may look confusing at first, it makes the functions very "
-"flexible as the user can pass a ``SELECT`` statement as function argument"
-" as long as the returned result contains the required number of "
-"attributes and the correct attribute names."
+"Many pgRouting functions have ``sql::text`` as one of their arguments. While "
+"this may look confusing at first, it makes the functions very flexible as "
+"the user can pass a ``SELECT`` statement as function argument as long as the "
+"returned result contains the required number of attributes and the correct "
+"attribute names."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:56
-msgid "Most of pgRouting implemented algorithms do not require the **geometry**."
+msgid ""
+"Most of pgRouting implemented algorithms do not require the **geometry**."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:57
 msgid ""
-"The pgRouting functions **do not** return a geometry, but only an ordered"
-" list of nodes or edges."
+"The pgRouting functions **do not** return a geometry, but only an ordered "
+"list of nodes or edges."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:61
@@ -88,11 +89,11 @@ msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:62
 msgid ""
-"The assignment of the vertices identifiers on the source and target "
-"columns may be different, the following exercises will use the results of"
-" this query. For the workshop, some locations near of the FOSS4G event "
-"are going to be used. These locations are within this area "
-"https://www.openstreetmap.org/#map=14/-1.44228/-48.46069"
+"The assignment of the vertices identifiers on the source and target columns "
+"may be different, the following exercises will use the results of this "
+"query. For the workshop, some locations near of the FOSS4G event are going "
+"to be used. These locations are within this area https://www.openstreetmap."
+"org/#map=14/-1.44228/-48.46069"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:67
@@ -145,8 +146,8 @@ msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:98
 msgid ""
-"The corresponding :code:`id` are shown in the following image, and a "
-"sample route from \"|place_3|\" to \"|place_5|\"."
+"The corresponding :code:`id` are shown in the following image, and a sample "
+"route from \"|place_3|\" to \"|place_5|\"."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:105
@@ -182,7 +183,8 @@ msgid "to \"|place_3|\"."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:114
-msgid "Calculate routes with costs in *osm2pgRouting* ``length`` default units."
+msgid ""
+"Calculate routes with costs in *osm2pgRouting* ``length`` default units."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:116
@@ -201,15 +203,14 @@ msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:122
 msgid ""
-"The pedestrian wants to go from vertex |id_1| to vertex |id_3| (lines "
-"**9** and **10**)."
+"The pedestrian wants to go from vertex |id_1| to vertex |id_3| (lines **9** "
+"and **10**)."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:123
 msgid ""
-"The pedestrian's cost is in terms of length. In this case ``length`` "
-"(line **6**), which was calculated by osm2pgrouting, is in unit "
-"``degrees``."
+"The pedestrian's cost is in terms of length. In this case ``length`` (line "
+"**6**), which was calculated by osm2pgrouting, is in unit ``degrees``."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:125
@@ -220,16 +221,16 @@ msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:139
 msgid ""
-"The returned cost attribute represents the cost specified in the inner "
-"SQL query (``edges_sql::text`` argument). In this example cost is "
-"``length`` in unit \"degrees\". Cost may be time, distance or any "
-"combination of both or any other attributes or a custom formula."
+"The returned cost attribute represents the cost specified in the inner SQL "
+"query (``edges_sql::text`` argument). In this example cost is ``length`` in "
+"unit \"degrees\". Cost may be time, distance or any combination of both or "
+"any other attributes or a custom formula."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:143
 msgid ""
-"``node`` and ``edge`` results may vary depending on the assignment of the"
-" identifiers to the vertices given by osm2pgrouting."
+"``node`` and ``edge`` results may vary depending on the assignment of the "
+"identifiers to the vertices given by osm2pgrouting."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:147
@@ -256,7 +257,8 @@ msgid "From |place_1| and |place_2| to |place_3|"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:164
-msgid "The pedestrians are departing at vertices |id_1| and |id_2| (line **9**)."
+msgid ""
+"The pedestrians are departing at vertices |id_1| and |id_2| (line **9**)."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:165
@@ -293,8 +295,8 @@ msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:197
 msgid ""
-"The cost to be in seconds, with a walking speed ``s = 1.3 m/s`` and ``t ="
-" d/s`` (line **6**)."
+"The cost to be in seconds, with a walking speed ``s = 1.3 m/s`` and ``t = d/"
+"s`` (line **6**)."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:211
@@ -320,15 +322,14 @@ msgstr ""
 #: ../../build/docs/basic/pedestrian.rst:317
 #: ../../build/docs/basic/pedestrian.rst:349
 msgid ""
-"The pedestrians want to go to destinations |id_4| and |id_5| (line "
-"**10**)."
+"The pedestrians want to go to destinations |id_4| and |id_5| (line **10**)."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:229
 #: ../../build/docs/basic/pedestrian.rst:318
 msgid ""
-"The cost to be in minutes, with a walking speed ``s = 1.3 m/s`` and ``t ="
-" d/s`` (line **6**)."
+"The cost to be in minutes, with a walking speed ``s = 1.3 m/s`` and ``t = d/"
+"s`` (line **6**)."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:230
@@ -341,19 +342,19 @@ msgid "Inspecting the results, looking for totals (edge = -1):"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:3
-msgid "From 20297 to vertex 6548 takes 92.58 minutes (seq = 147)"
+msgid "From 10840 to vertex 10928 takes 9.61 minutes (seq = 120)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:5
-msgid "From 20297 to vertex 12712 takes 83.18 minutes (seq = 267)"
+msgid "From 10840 to vertex 12777 takes 10.44 minutes (seq = 163)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:7
-msgid "From 23872 to vertex 6548 takes 76.26 minutes (seq = 385)"
+msgid "From 936 to vertex 10928 takes 8.94 minutes (seq = 34)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:9
-msgid "From 23872 to vertex 12712 takes 67.76 minutes (seq = 495)"
+msgid "From 936 to vertex 12777 takes 8.90 minutes (seq = 69)"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:245
@@ -376,14 +377,14 @@ msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:262
 msgid ""
-"Second pedestrian departs from |id_2| and the destination is |id_5| (line"
-" **12**)."
+"Second pedestrian departs from |id_2| and the destination is |id_5| (line "
+"**12**)."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:263
 msgid ""
-"The cost to be in minutes, with a walking speed ``s = 1.3 m/s`` and ``t ="
-" d/s``"
+"The cost to be in minutes, with a walking speed ``s = 1.3 m/s`` and ``t = d/"
+"s``"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:276
@@ -392,16 +393,16 @@ msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:278
 msgid ""
-"When the main goal is to calculate the total cost, without \"inspecting\""
-" the `pgr_dijkstra` results, using ``pgr_dijkstraCost`` returns a more "
+"When the main goal is to calculate the total cost, without \"inspecting\" "
+"the `pgr_dijkstra` results, using ``pgr_dijkstraCost`` returns a more "
 "compact result."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:294
 msgid ""
-"Description of the parameters can be found in `pgr_dijkstraCost "
-"<https://docs.pgrouting.org/latest/en/pgr_dijkstraCost.html#description-"
-"of-the-signatures>`__"
+"Description of the parameters can be found in `pgr_dijkstraCost <https://"
+"docs.pgrouting.org/latest/en/pgr_dijkstraCost.html#description-of-the-"
+"signatures>`__"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:299
@@ -432,14 +433,14 @@ msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:331
 msgid ""
-"Compare with `Exercise 4: Many Pedestrians going to different "
-"destinations`_ 's note."
+"Compare with `Exercise 4: Many Pedestrians going to different destinations`_ "
+"'s note."
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:335
 msgid ""
-"Exercise 7: Many Pedestrians going to different destinations summarizing "
-"the total costs per departure"
+"Exercise 7: Many Pedestrians going to different destinations summarizing the "
+"total costs per departure"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:344
@@ -454,8 +455,6 @@ msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_2.txt:1
 msgid ""
-"An interpretation of the result can be: In general, it is faster to "
-"depart from \"Instituto Federal do Pará, Campus Belém\" than from "
-"\"Hangar Convention Center\""
+"An interpretation of the result can be: In general, it is faster to depart "
+"from \"The Band Rotunda\" than from \"Auckland University of Technology\""
 msgstr ""
-

--- a/locale/en/LC_MESSAGES/basic/plpgsql_function.po
+++ b/locale/en/LC_MESSAGES/basic/plpgsql_function.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-10 17:09+0000\n"
+"POT-Creation-Date: 2025-09-30 17:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: ../../build/docs/basic/plpgsql_function.rst:11
 msgid "pl/pgsql function"
@@ -26,10 +26,10 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:17
 msgid ""
-"Other kind of functions are `pl/pgsql "
-"<https://www.postgresql.org/docs/current/plpgsql.html>`__. As the "
-"applications requirements become more complex, using wrappers of "
-"previously defined functions becomes necessary for clarity."
+"Other kind of functions are `pl/pgsql <https://www.postgresql.org/docs/"
+"current/plpgsql.html>`__. As the applications requirements become more "
+"complex, using wrappers of previously defined functions becomes necessary "
+"for clarity."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:22
@@ -45,7 +45,8 @@ msgid "Chapter problem:"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:29
-msgid "Create a function ``wrk_fromAtoB`` that allows routing from 2 geometries."
+msgid ""
+"Create a function ``wrk_fromAtoB`` that allows routing from 2 geometries."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:30
@@ -54,8 +55,8 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:31
 msgid ""
-"Returns a route that includes a geometry so that if can be displayed, for"
-" example, in QGIS."
+"Returns a route that includes a geometry so that if can be displayed, for "
+"example, in QGIS."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:32
@@ -225,11 +226,11 @@ msgid "For this chapter, the following points will be used for testing."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:68
-msgid "(lat,lon) = (-1.455829, -48.446044)"
+msgid "(lat,lon) = (-36.8471438, 174.7710042)"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:69
-msgid "(lat,lon) = (-1.453448, -48.447142)"
+msgid "(lat,lon) = (-36.8524328, 174.766749)"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:72
@@ -238,8 +239,8 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:74
 msgid ""
-"Graphs have a `set of edges` and a `set of vertices` associated to it. "
-"The views need their vertices table."
+"Graphs have a `set of edges` and a `set of vertices` associated to it. The "
+"views need their vertices table."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:78
@@ -282,14 +283,14 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:91
 msgid ""
-"Use ``pgr_extractVertices`` (explained in :doc:`graphs`) to create "
-"the vertices table"
+"Use ``pgr_extractVertices`` (explained in :doc:`graphs`) to create the "
+"vertices table"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:93
 msgid ""
-"``JOIN`` the vertices table with ``ways_vertices`` (created in "
-":doc:`graphs`) to get the ``x``, ``y``, ``geom`` information."
+"``JOIN`` the vertices table with ``ways_vertices`` (created in :doc:"
+"`graphs`) to get the ``x``, ``y``, ``geom`` information."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:96
@@ -332,8 +333,8 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:131
 msgid ""
-"In particular use the following (lat, lon) value: ``(-1.455829, "
-"-48.446044)``."
+"In particular use the following (lat, lon) value: ``(-36.8471438, "
+"174.7710042)``."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:133
@@ -363,15 +364,13 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:142
 msgid ""
-"Remember that the ``id`` has an OSM vertex identifier on the vertices "
-"tables."
+"Remember that the ``id`` has an OSM vertex identifier on the vertices tables."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:143
 msgid ""
-"Using the Postgis distance operator `<-> "
-"<https://postgis.net/docs/geometry_distance_knn.html>`__ to order by "
-"distance."
+"Using the Postgis distance operator `<-> <https://postgis.net/docs/"
+"geometry_distance_knn.html>`__ to order by distance."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:144
@@ -411,14 +410,13 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:194
 msgid ""
-"When operations look similar for different tables, a function can be "
-"created."
+"When operations look similar for different tables, a function can be created."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:196
 msgid ""
-"Create a function that calculates the OSM identifier of the nearest "
-"vertex to a point."
+"Create a function that calculates the OSM identifier of the nearest vertex "
+"to a point."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:197
@@ -475,8 +473,8 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:222
 msgid ""
-"Using `format <https://www.postgresql.org/docs/12/functions-string.html"
-"#FUNCTIONS-STRING-FORMAT>`__ to build the query."
+"Using `format <https://www.postgresql.org/docs/12/functions-string."
+"html#FUNCTIONS-STRING-FORMAT>`__ to build the query."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:226
@@ -518,7 +516,7 @@ msgid "Test the ``wrk_Nearest`` function."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:259
-msgid "Use the following (lat,lon) values: ``(-1.455829, -48.446044)``."
+msgid "Use the following (lat,lon) values: ``(-36.8471438, 174.7710042)``."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:261
@@ -530,7 +528,8 @@ msgid "Verify the results are the same."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:276
-msgid "Use the function with ``ways_vertices`` as the ``vertex_table`` parameter."
+msgid ""
+"Use the function with ``ways_vertices`` as the ``vertex_table`` parameter."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:277
@@ -539,8 +538,7 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:278
 msgid ""
-"Using the function on the original data does not return the OSM "
-"identifier."
+"Using the function on the original data does not return the OSM identifier."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:280
@@ -557,8 +555,7 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:322
 msgid ""
-"In this section, creation and testing the required function will be "
-"tackled."
+"In this section, creation and testing the required function will be tackled."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:326
@@ -570,7 +567,8 @@ msgid "Create the function ``wrk_fromAtoB``."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:331
-msgid "Follow the description given at `Requirements for routing from A to B`_."
+msgid ""
+"Follow the description given at `Requirements for routing from A to B`_."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:332
@@ -682,11 +680,11 @@ msgid "Use ``wrk_fromAtoB``"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:408
-msgid "Departure point is: (lat,lon) = ``(-1.455829, -48.446044)``"
+msgid "Departure point is: (lat,lon) = ``(-36.8471438, 174.7710042)``"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:409
-msgid "Destination point is: (lat,lon) = ``(-1.453448, -48.447142)``"
+msgid "Destination point is: (lat,lon) = ``(-36.8524328, 174.766749)``"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:412
@@ -722,11 +720,10 @@ msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:433
 msgid ""
-"The next two parameters are the latitude and longitude of the destination"
-" point."
+"The next two parameters are the latitude and longitude of the destination "
+"point."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:446
 msgid "Do a dry run by adding ``true`` to get the query that is executed."
 msgstr ""
-

--- a/locale/en/LC_MESSAGES/general-intro/introduction.po
+++ b/locale/en/LC_MESSAGES/general-intro/introduction.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:44+0000\n"
+"POT-Creation-Date: 2025-09-30 17:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: ../../build/docs/general-intro/introduction.rst:11
 msgid "Introduction"
@@ -31,7 +31,7 @@ msgstr ""
 #: ../../build/docs/general-intro/introduction.rst:15
 msgid ""
 "Please see the :doc:`contents <../index>` for full content of FOSS4G "
-"Belém workshop. This workshop covers two levels for using pgRouting: "
+"Auckland workshop. This workshop covers two levels for using pgRouting: "
 "`Basic`_ and `Advanced`_."
 msgstr ""
 
@@ -41,11 +41,10 @@ msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:22
 msgid ""
-"will demonstrate the routing functionality by providing examples using "
-"|osm-web| road network data from Belém. Covering topics from how to "
-"prepare the data, making routing queries, understanding the results, up "
-"to writing a custom 'plpgsql' function that can be integrated with other "
-"FOSS tools."
+"will demonstrate the routing functionality by providing examples using |osm-"
+"web| road network data from Auckland. Covering topics from how to prepare "
+"the data, making routing queries, understanding the results, up to writing a "
+"custom 'plpgsql' function that can be integrated with other FOSS tools."
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:28
@@ -96,9 +95,9 @@ msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:44
 msgid ""
-"pgRouting is an extendible open-source library that provides a variety of"
-" tools for graph algorithms, this is not limited to routing vehicles. The"
-" advanced section covers several graph problems that can be solved using "
+"pgRouting is an extendible open-source library that provides a variety of "
+"tools for graph algorithms, this is not limited to routing vehicles. The "
+"advanced section covers several graph problems that can be solved using "
 "pgRouting."
 msgstr ""
 
@@ -124,7 +123,7 @@ msgid "Paragon Corporation"
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:70
-msgid "Developers & presenters of FOSS4G Belém workshop:"
+msgid "Developers & presenters of FOSS4G Auckland workshop:"
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:71
@@ -145,8 +144,8 @@ msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:80
 msgid ""
-"Daniel Kastl, José Ríos, Ko Nagase, Stephen Woodbridge, Swapnil Joshi, "
-"Rajat Shinde, Ramón Ríos, Rohith Reddy, Vicky Vergara"
+"Daniel Kastl, José Ríos, Ko Nagase, Stephen Woodbridge, Swapnil Joshi, Rajat "
+"Shinde, Ramón Ríos, Rohith Reddy, Vicky Vergara"
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:91
@@ -163,8 +162,8 @@ msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:97
 msgid ""
-"This work is licensed under a `Creative Commons Attribution-Share Alike "
-"3.0 License <https://creativecommons.org/licenses/by-sa/3.0/>`_."
+"This work is licensed under a `Creative Commons Attribution-Share Alike 3.0 "
+"License <https://creativecommons.org/licenses/by-sa/3.0/>`_."
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:103
@@ -182,4 +181,3 @@ msgstr ""
 #: ../../build/docs/general-intro/introduction.rst:115
 msgid "OSGeo Foundation"
 msgstr ""
-

--- a/locale/pot/basic/data.pot
+++ b/locale/pot/basic/data.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2010-2024 pgRouting Developers
-# This file is distributed under the same license as the Workshop FOSS4G Belém package.
+# Copyright (C) 2010-2025 pgRouting Developers
+# This file is distributed under the same license as the Workshop FOSS4G Auckland package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
+"Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:44+0000\n"
+"POT-Creation-Date: 2025-09-30 17:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -73,7 +73,7 @@ msgid "Get the Workshop Data"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:58
-msgid "The pgRouting workshop will make use of OpenStreetMap data, which is already available on `OSGeoLive <https://live.osgeo.org>`_. This workshop will use the ``Belém`` city data and is a snapshot of Sep 2024."
+msgid "The pgRouting workshop will make use of OpenStreetMap data, which is already available on `OSGeoLive <https://live.osgeo.org>`_. This workshop will use the ``Auckland`` city data and is a snapshot of Jun 2025."
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:63
@@ -85,7 +85,7 @@ msgid "Option 1) When using OSGeoLive"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:68
-msgid "OSGeoLive comes with OSM data from the city of Belém."
+msgid "OSGeoLive comes with OSM data from the city of Auckland."
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:76
@@ -101,7 +101,7 @@ msgid "Option 3) Download using Overpass XAPI"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:88
-msgid "The following downloads the latest OSM data on using the same area. Using this data in the workshop can generate variations in the results, due to changes since Sep 2024."
+msgid "The following downloads the latest OSM data on using the same area. Using this data in the workshop can generate variations in the results, due to changes since Jun 2025."
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:98
@@ -129,7 +129,7 @@ msgid "the osm2pgrouting default ``mapconfig.xml`` configuration file is used"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:115
-msgid "and the ``~/Desktop/workshop/BELEM_BR.osm`` data"
+msgid "and the ``~/Desktop/workshop/auckland_NZ.osm`` data"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:116

--- a/locale/pot/basic/graphs.pot
+++ b/locale/pot/basic/graphs.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 18:24+0000\n"
+"POT-Creation-Date: 2025-09-30 18:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -90,7 +90,7 @@ msgid "`motorways` and on `primary` segments."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:57
-#: ../../build/docs/basic/graphs.rst:488
+#: ../../build/docs/basic/graphs.rst:487
 msgid "The speed is ``2 mts/sec``."
 msgstr ""
 
@@ -99,494 +99,494 @@ msgid "pgr_extractVertices"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:62
-msgid "``pgr_extractVertices`` compute the connected components of an undirected graph using a Depth First Search approach. A connected component of an undirected graph is a set of vertices that are all reachable from each other."
+msgid "``pgr_extractVertices`` extracts the vertices (nodes) from an edge table and reports per-vertex attributes such as degree"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:67
-#: ../../build/docs/basic/graphs.rst:214
+#: ../../build/docs/basic/graphs.rst:66
+#: ../../build/docs/basic/graphs.rst:213
 msgid "Signature summary"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:75
+#: ../../build/docs/basic/graphs.rst:74
 msgid "Description of the function can be found in `pgr_extractVertices <https://docs.pgrouting.org/latest/en/pgr_extractVertices.html>`__"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:79
+#: ../../build/docs/basic/graphs.rst:78
 msgid "Exercise 1: Create a vertices table"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:82
-#: ../../build/docs/basic/graphs.rst:130
-#: ../../build/docs/basic/graphs.rst:230
-#: ../../build/docs/basic/graphs.rst:278
-#: ../../build/docs/basic/graphs.rst:355
-#: ../../build/docs/basic/graphs.rst:426
-#: ../../build/docs/basic/graphs.rst:484
-#: ../../build/docs/basic/graphs.rst:548
+#: ../../build/docs/basic/graphs.rst:81
+#: ../../build/docs/basic/graphs.rst:129
+#: ../../build/docs/basic/graphs.rst:229
+#: ../../build/docs/basic/graphs.rst:277
+#: ../../build/docs/basic/graphs.rst:354
+#: ../../build/docs/basic/graphs.rst:425
+#: ../../build/docs/basic/graphs.rst:483
+#: ../../build/docs/basic/graphs.rst:547
 msgid "Problem"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:83
+#: ../../build/docs/basic/graphs.rst:82
 msgid "Create the vertices table corresponding to the edges in ``ways``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:86
-#: ../../build/docs/basic/graphs.rst:134
-#: ../../build/docs/basic/graphs.rst:234
-#: ../../build/docs/basic/graphs.rst:287
-#: ../../build/docs/basic/graphs.rst:369
-#: ../../build/docs/basic/graphs.rst:435
-#: ../../build/docs/basic/graphs.rst:499
-#: ../../build/docs/basic/graphs.rst:567
+#: ../../build/docs/basic/graphs.rst:85
+#: ../../build/docs/basic/graphs.rst:133
+#: ../../build/docs/basic/graphs.rst:233
+#: ../../build/docs/basic/graphs.rst:286
+#: ../../build/docs/basic/graphs.rst:368
+#: ../../build/docs/basic/graphs.rst:434
+#: ../../build/docs/basic/graphs.rst:498
+#: ../../build/docs/basic/graphs.rst:566
 msgid "Solution"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:87
+#: ../../build/docs/basic/graphs.rst:86
 msgid "A graph consists of a set of vertices and a set of edges."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:88
+#: ../../build/docs/basic/graphs.rst:87
 msgid "In this case, the ``ways`` table is a set of edges."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:89
+#: ../../build/docs/basic/graphs.rst:88
 msgid "In order to make use of all the graph functions from pgRouting, it is required have the set of vertices defined."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:91
+#: ../../build/docs/basic/graphs.rst:90
 msgid "From the requirements, the graph is going to be based on OSM identifiers."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:104
+#: ../../build/docs/basic/graphs.rst:103
 msgid "Reviewing the description of the vertices table"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:114
+#: ../../build/docs/basic/graphs.rst:113
 msgid "Inspecting the information on the vertices table"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:127
+#: ../../build/docs/basic/graphs.rst:126
 msgid "Exercise 2: Fill up other columns in the vertices table"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:131
+#: ../../build/docs/basic/graphs.rst:130
 msgid "Fill up geometry information on the vertices table."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:135
+#: ../../build/docs/basic/graphs.rst:134
 msgid "Count the number of rows that need to be filled up."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:145
+#: ../../build/docs/basic/graphs.rst:144
 msgid "Update the ``geom`` columns based on the ``source_osm`` column from ``ways`` table."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:147
+#: ../../build/docs/basic/graphs.rst:146
 msgid "Use the start point of the geometry."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:158
+#: ../../build/docs/basic/graphs.rst:157
 msgid "Not expecting to be done due to the fact that some vertices are only dead ends."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:169
+#: ../../build/docs/basic/graphs.rst:168
 msgid "Update the ``geom`` columns based on the ``target_osm`` column from ``ways`` table."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:171
+#: ../../build/docs/basic/graphs.rst:170
 msgid "Use the end point of the geometry."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:182
+#: ../../build/docs/basic/graphs.rst:181
 msgid "Expecting to be done, that is the geometry column should not have a ``NULL`` value."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:194
+#: ../../build/docs/basic/graphs.rst:193
 msgid "Update the ``x`` and ``y`` columns based on the ``geom`` column."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:207
+#: ../../build/docs/basic/graphs.rst:206
 msgid "pgr_connectedComponents"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:209
+#: ../../build/docs/basic/graphs.rst:208
 msgid "``pgr_connectedComponents`` compute the connected components of an undirected graph using a Depth First Search approach. A connected component of an undirected graph is a set of vertices that are all reachable from each other."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:222
+#: ../../build/docs/basic/graphs.rst:221
 msgid "Description of the function can be found in `pgr_connectedComponents <https://docs.pgrouting.org/latest/en/pgr_connectedComponents.html>`__"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:227
+#: ../../build/docs/basic/graphs.rst:226
 msgid "Exercise 3: Set components on edges and vertices tables"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:231
+#: ../../build/docs/basic/graphs.rst:230
 msgid "Get the information about the graph components."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:235
+#: ../../build/docs/basic/graphs.rst:234
 msgid "Create additional columns on the edges and vertices tables."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:246
+#: ../../build/docs/basic/graphs.rst:245
 msgid "Use the ``pgr_connectedComponents`` to fill up the vertices table."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:248
+#: ../../build/docs/basic/graphs.rst:247
 msgid "Use the results to store the component numbers on the vertices table. (**line 1**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:250
+#: ../../build/docs/basic/graphs.rst:249
 msgid "Use the OSM identifiers of the vertices. (**lines 4-5**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:262
+#: ../../build/docs/basic/graphs.rst:261
 msgid "Update the edges table with based on the component number of the vertex"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:275
+#: ../../build/docs/basic/graphs.rst:274
 msgid "Exercise 4: Inspect the components"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:279
+#: ../../build/docs/basic/graphs.rst:278
 msgid "Answer the following questions:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:281
-#: ../../build/docs/basic/graphs.rst:288
+#: ../../build/docs/basic/graphs.rst:280
+#: ../../build/docs/basic/graphs.rst:287
 msgid "How many components are in the vertices table?"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:282
-#: ../../build/docs/basic/graphs.rst:301
+#: ../../build/docs/basic/graphs.rst:281
+#: ../../build/docs/basic/graphs.rst:300
 msgid "How many components are in the edges table?"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:283
-#: ../../build/docs/basic/graphs.rst:314
+#: ../../build/docs/basic/graphs.rst:282
+#: ../../build/docs/basic/graphs.rst:313
 msgid "List the 10 components with more edges."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:284
-#: ../../build/docs/basic/graphs.rst:328
+#: ../../build/docs/basic/graphs.rst:283
+#: ../../build/docs/basic/graphs.rst:327
 msgid "Get the component with the maximum number of edges."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:290
-#: ../../build/docs/basic/graphs.rst:303
+#: ../../build/docs/basic/graphs.rst:289
+#: ../../build/docs/basic/graphs.rst:302
 msgid "Count the distinct components."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:316
+#: ../../build/docs/basic/graphs.rst:315
 msgid "Count number of rows grouped by component. (**line 1**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:317
+#: ../../build/docs/basic/graphs.rst:316
 msgid "Inverse order to display the top 10. (**line 2**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:330
+#: ../../build/docs/basic/graphs.rst:329
 msgid "Use the query from last question to get the maximum count"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:331
+#: ../../build/docs/basic/graphs.rst:330
 msgid "Get the component that matches the maximum value."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:345
+#: ../../build/docs/basic/graphs.rst:344
 msgid "Preparing the graphs"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:348
+#: ../../build/docs/basic/graphs.rst:347
 msgid "Exercise 5: Creating a view for routing"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:350
+#: ../../build/docs/basic/graphs.rst:349
 msgid "View of roads for vehicles"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:356
+#: ../../build/docs/basic/graphs.rst:355
 msgid "Create a view with minimal amount of information for processing the particular vehicles."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:357
+#: ../../build/docs/basic/graphs.rst:356
 msgid "Use the OSM identifiers on the vertices."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:358
+#: ../../build/docs/basic/graphs.rst:357
 msgid "Routing `cost` and `reverse_cost` in terms of seconds for routing calculations."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:359
+#: ../../build/docs/basic/graphs.rst:358
 msgid "Exclude `steps`, `footway`, `path`, `cycleway` segments."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:360
-#: ../../build/docs/basic/graphs.rst:491
+#: ../../build/docs/basic/graphs.rst:359
+#: ../../build/docs/basic/graphs.rst:490
 msgid "Data needed in the view for further processing."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:362
+#: ../../build/docs/basic/graphs.rst:361
 msgid "`name` The name of the segment."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:363
+#: ../../build/docs/basic/graphs.rst:362
 msgid "`length_m` The length in meters rename to ``length``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:364
+#: ../../build/docs/basic/graphs.rst:363
 msgid "`the_geom` The geometry rename to ``geom``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:366
-#: ../../build/docs/basic/graphs.rst:496
+#: ../../build/docs/basic/graphs.rst:365
+#: ../../build/docs/basic/graphs.rst:495
 msgid "Verify the number of edges was reduced."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:370
-#: ../../build/docs/basic/graphs.rst:436
-#: ../../build/docs/basic/graphs.rst:500
+#: ../../build/docs/basic/graphs.rst:369
+#: ../../build/docs/basic/graphs.rst:435
+#: ../../build/docs/basic/graphs.rst:499
 msgid "Creating the view:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:372
+#: ../../build/docs/basic/graphs.rst:371
 msgid "If you need to reconstruct the view, first drop it using the command on **line 1**."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:374
+#: ../../build/docs/basic/graphs.rst:373
 msgid "Get the component with maximum number of edges (**lines 6-10**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:375
+#: ../../build/docs/basic/graphs.rst:374
 msgid "The `source` and `target` requirements for the function are to be with OSM identifiers. (line **14**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:377
+#: ../../build/docs/basic/graphs.rst:376
 msgid "The ``cost`` and ``reverse_cost`` are in terms of seconds. (line **15**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:378
+#: ../../build/docs/basic/graphs.rst:377
 msgid "The additional parameters ``length_m`` and ``the_geom`` are renamed, ``name`` is also included. (line **16**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:380
+#: ../../build/docs/basic/graphs.rst:379
 msgid "``JOIN`` with the `configuration`:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:382
+#: ../../build/docs/basic/graphs.rst:381
 msgid "Exclude `steps`, `footway`, `path`, `cycleway`. (line **18**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:395
+#: ../../build/docs/basic/graphs.rst:394
 msgid "Verification:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:397
+#: ../../build/docs/basic/graphs.rst:396
 msgid "Count the rows on the original ``ways`` and on ``vehicle_net``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:407
+#: ../../build/docs/basic/graphs.rst:406
 msgid "Get the description of the view"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:419
+#: ../../build/docs/basic/graphs.rst:418
 msgid "Exercise 6: Limiting the road network within an area"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:421
+#: ../../build/docs/basic/graphs.rst:420
 msgid "View of smaller set of roads for vehicles"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:427
+#: ../../build/docs/basic/graphs.rst:426
 msgid "Create a view ``taxi_net`` for the `taxi`:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:429
+#: ../../build/docs/basic/graphs.rst:428
 msgid "The taxi can only circulate inside this Bounding Box: ``(174.775,-36.855,174.76,-36.84)``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:430
+#: ../../build/docs/basic/graphs.rst:429
 msgid "The taxi speed is 10% slower than the particular vehicle."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:432
+#: ../../build/docs/basic/graphs.rst:431
 msgid "Verify the reduced number of road segments."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:438
+#: ../../build/docs/basic/graphs.rst:437
 msgid "Adjust the taxi's ``cost`` and ``reverse_cost`` to be 10% slower than of the particular vehicle. (line **7**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:440
+#: ../../build/docs/basic/graphs.rst:439
 msgid "The graph for the taxi is a subset of the ``vehicle_net`` graph. (line **9**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:441
+#: ../../build/docs/basic/graphs.rst:440
 msgid "Can only circulate inside the bounding box: ``(174.775,-36.855,174.76,-36.84)``. (line **10**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:455
+#: ../../build/docs/basic/graphs.rst:454
 msgid "Count the rows on ``taxi_net``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:466
-#: ../../build/docs/basic/graphs.rst:529
+#: ../../build/docs/basic/graphs.rst:465
+#: ../../build/docs/basic/graphs.rst:528
 msgid "Get the description."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:477
+#: ../../build/docs/basic/graphs.rst:476
 msgid "Exercise 7: Creating a materialized view for routing pedestrians"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:479
+#: ../../build/docs/basic/graphs.rst:478
 msgid "View of roads for pedestrians"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:485
+#: ../../build/docs/basic/graphs.rst:484
 msgid "Create a materialized view with minimal amount of information for processing pedestrians."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:486
+#: ../../build/docs/basic/graphs.rst:485
 msgid "Routing `cost` and `reverse_cost` will be on seconds for routing calculations."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:490
+#: ../../build/docs/basic/graphs.rst:489
 msgid "Exclude `motorway` , `primary` and `secondary` segments."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:493
+#: ../../build/docs/basic/graphs.rst:492
 msgid "`length_m` The length in meters."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:494
+#: ../../build/docs/basic/graphs.rst:493
 msgid "`the_geom` The geometry."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:502
+#: ../../build/docs/basic/graphs.rst:501
 msgid "Similar to `Exercise 5: Creating a view for routing`_:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:504
+#: ../../build/docs/basic/graphs.rst:503
 msgid "The ``cost`` and ``reverse_cost`` are in terms of seconds with speed of ``2 mts/sec``. (line **7**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:505
+#: ../../build/docs/basic/graphs.rst:504
 msgid "Exclude `motorway`, `primary` and `secondary` . (line **11**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:518
+#: ../../build/docs/basic/graphs.rst:517
 msgid "Count the rows on the view ``walk_net``."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:541
+#: ../../build/docs/basic/graphs.rst:540
 msgid "Exercise 8: Testing the views for routing"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:543
+#: ../../build/docs/basic/graphs.rst:542
 msgid "From the |ch7_place_1| to the |ch7_place_2|"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:549
+#: ../../build/docs/basic/graphs.rst:548
 msgid "Test the created views"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:551
+#: ../../build/docs/basic/graphs.rst:550
 msgid "In particular:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:553
+#: ../../build/docs/basic/graphs.rst:552
 msgid "From the |ch7_place_1| to the \"|ch7_place_2| using the OSM identifier"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:554
+#: ../../build/docs/basic/graphs.rst:553
 msgid "the views to be tested are:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:556
+#: ../../build/docs/basic/graphs.rst:555
 msgid "``vehicle_net``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:557
+#: ../../build/docs/basic/graphs.rst:556
 msgid "``taxi_net``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:558
+#: ../../build/docs/basic/graphs.rst:557
 msgid "``walk_net``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:560
+#: ../../build/docs/basic/graphs.rst:559
 msgid "Only show the following results, as the other columns are to be ignored on the function."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:562
+#: ../../build/docs/basic/graphs.rst:561
 msgid "``seq``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:563
+#: ../../build/docs/basic/graphs.rst:562
 msgid "``edge`` with the name ``id``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:564
+#: ../../build/docs/basic/graphs.rst:563
 msgid "``cost`` with the name: ``seconds``"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:568
+#: ../../build/docs/basic/graphs.rst:567
 msgid "In general"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:570
+#: ../../build/docs/basic/graphs.rst:569
 msgid "The departure is |ch7_place_1| with OSM identifier |ch7_osmid_1|."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:571
+#: ../../build/docs/basic/graphs.rst:570
 msgid "The destination is |ch7_place_2| with OSM identifier |ch7_osmid_2|."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:573
+#: ../../build/docs/basic/graphs.rst:572
 msgid "For ``vehicle_net``:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:575
+#: ../../build/docs/basic/graphs.rst:574
 msgid "``vehicle_net`` is used."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:576
+#: ../../build/docs/basic/graphs.rst:575
 msgid "Selection of the columns with the corresponding names are on line **1**."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:577
+#: ../../build/docs/basic/graphs.rst:576
 msgid "The view is prepared with the column names that pgRouting use."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:579
+#: ../../build/docs/basic/graphs.rst:578
 msgid "There is no need to rename columns. (line **3**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:581
+#: ../../build/docs/basic/graphs.rst:580
 msgid "The OSM identifiers of the departure and destination are used. (line **4**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:594
+#: ../../build/docs/basic/graphs.rst:593
 msgid "For ``taxi_net``:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:596
+#: ../../build/docs/basic/graphs.rst:595
 msgid "Similar as the previous one but with ``taxi_net``. (line **3**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:597
+#: ../../build/docs/basic/graphs.rst:596
 msgid "The results give the same route as with ``vehicle_net`` but ``cost`` is higher."
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:610
+#: ../../build/docs/basic/graphs.rst:609
 msgid "For ``walk_net``:"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:612
+#: ../../build/docs/basic/graphs.rst:611
 msgid "Similar as the previous one but with ``walk_net``. (line **3**)"
 msgstr ""
 
-#: ../../build/docs/basic/graphs.rst:613
+#: ../../build/docs/basic/graphs.rst:612
 msgid "The results give a different route than of the vehicles."
 msgstr ""

--- a/locale/pot/basic/graphs.pot
+++ b/locale/pot/basic/graphs.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 17:36+0000\n"
+"POT-Creation-Date: 2025-09-30 18:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -108,7 +108,7 @@ msgid "Signature summary"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:75
-msgid "Description of the function can be found in `pgr_extractVertices <https://docs.pgrouting.org/latest/en/pgr_connectedComponents.html>`__"
+msgid "Description of the function can be found in `pgr_extractVertices <https://docs.pgrouting.org/latest/en/pgr_extractVertices.html>`__"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:79

--- a/locale/pot/basic/graphs.pot
+++ b/locale/pot/basic/graphs.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2010-2024 pgRouting Developers
-# This file is distributed under the same license as the Workshop FOSS4G Belém package.
+# Copyright (C) 2010-2025 pgRouting Developers
+# This file is distributed under the same license as the Workshop FOSS4G Auckland package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
+"Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-10 17:09+0000\n"
+"POT-Creation-Date: 2025-09-30 17:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,7 +45,7 @@ msgid "Particular vehicle:"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:35
-msgid "Circulate on the whole Belém area."
+msgid "Circulate on the whole Auckland area."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:37
@@ -66,7 +66,7 @@ msgid "Circulate on a smaller area:"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:45
-msgid "Bounding box: ``(-48.52,-1.46,-48.45,-1.41)``"
+msgid "Bounding box: ``(174.775,-36.855,174.76,-36.84)``"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:48
@@ -78,7 +78,7 @@ msgid "Pedestrians:"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:52
-msgid "Walk on the whole Belém area."
+msgid "Walk on the whole Auckland area."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:53
@@ -403,7 +403,7 @@ msgid "Create a view ``taxi_net`` for the `taxi`:"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:429
-msgid "The taxi can only circulate inside this Bounding Box: ``(-48.52,-1.46,-48.45,-1.41)``"
+msgid "The taxi can only circulate inside this Bounding Box: ``(174.775,-36.855,174.76,-36.84)``"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:430
@@ -423,7 +423,7 @@ msgid "The graph for the taxi is a subset of the ``vehicle_net`` graph. (line **
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:441
-msgid "Can only circulate inside the bounding box: ``(-48.52,-1.46,-48.45,-1.41)``. (line **10**)"
+msgid "Can only circulate inside the bounding box: ``(174.775,-36.855,174.76,-36.84)``. (line **10**)"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:455

--- a/locale/pot/basic/pedestrian.pot
+++ b/locale/pot/basic/pedestrian.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2010-2024 pgRouting Developers
-# This file is distributed under the same license as the Workshop FOSS4G Belém package.
+# Copyright (C) 2010-2025 pgRouting Developers
+# This file is distributed under the same license as the Workshop FOSS4G Auckland package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
+"Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-10 17:09+0000\n"
+"POT-Creation-Date: 2025-09-30 17:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -292,19 +292,19 @@ msgid "Inspecting the results, looking for totals (edge = -1):"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:3
-msgid "From 20297 to vertex 6548 takes 92.58 minutes (seq = 147)"
+msgid "From 10840 to vertex 10928 takes 9.61 minutes (seq = 120)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:5
-msgid "From 20297 to vertex 12712 takes 83.18 minutes (seq = 267)"
+msgid "From 10840 to vertex 12777 takes 10.44 minutes (seq = 163)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:7
-msgid "From 23872 to vertex 6548 takes 76.26 minutes (seq = 385)"
+msgid "From 936 to vertex 10928 takes 8.94 minutes (seq = 34)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:9
-msgid "From 23872 to vertex 12712 takes 67.76 minutes (seq = 495)"
+msgid "From 936 to vertex 12777 takes 8.90 minutes (seq = 69)"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:245
@@ -386,5 +386,5 @@ msgid "The cost to be in minutes, with a walking speed s = 1.3 m/s and t = d/s (
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_2.txt:1
-msgid "An interpretation of the result can be: In general, it is faster to depart from \"Instituto Federal do Pará, Campus Belém\" than from \"Hangar Convention Center\""
+msgid "An interpretation of the result can be: In general, it is faster to depart from \"The Band Rotunda\" than from \"Auckland University of Technology\""
 msgstr ""

--- a/locale/pot/basic/plpgsql_function.pot
+++ b/locale/pot/basic/plpgsql_function.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2010-2024 pgRouting Developers
-# This file is distributed under the same license as the Workshop FOSS4G Belém package.
+# Copyright (C) 2010-2025 pgRouting Developers
+# This file is distributed under the same license as the Workshop FOSS4G Auckland package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
+"Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-10 17:09+0000\n"
+"POT-Creation-Date: 2025-09-30 17:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -213,11 +213,11 @@ msgid "For this chapter, the following points will be used for testing."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:68
-msgid "(lat,lon) = (-1.455829, -48.446044)"
+msgid "(lat,lon) = (-36.8471438, 174.7710042)"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:69
-msgid "(lat,lon) = (-1.453448, -48.447142)"
+msgid "(lat,lon) = (-36.8524328, 174.766749)"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:72
@@ -313,7 +313,7 @@ msgid "Calculate the (OSM) identifier of the nearest vertex to a point."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:131
-msgid "In particular use the following (lat, lon) value: ``(-1.455829, -48.446044)``."
+msgid "In particular use the following (lat, lon) value: ``(-36.8471438, 174.7710042)``."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:133
@@ -485,7 +485,7 @@ msgid "Test the ``wrk_Nearest`` function."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:259
-msgid "Use the following (lat,lon) values: ``(-1.455829, -48.446044)``."
+msgid "Use the following (lat,lon) values: ``(-36.8471438, 174.7710042)``."
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:261
@@ -645,11 +645,11 @@ msgid "Use ``wrk_fromAtoB``"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:408
-msgid "Departure point is: (lat,lon) = ``(-1.455829, -48.446044)``"
+msgid "Departure point is: (lat,lon) = ``(-36.8471438, 174.7710042)``"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:409
-msgid "Destination point is: (lat,lon) = ``(-1.453448, -48.447142)``"
+msgid "Destination point is: (lat,lon) = ``(-36.8524328, 174.766749)``"
 msgstr ""
 
 #: ../../build/docs/basic/plpgsql_function.rst:412

--- a/locale/pot/general-intro/introduction.pot
+++ b/locale/pot/general-intro/introduction.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2010-2024 pgRouting Developers
-# This file is distributed under the same license as the Workshop FOSS4G Belém package.
+# Copyright (C) 2010-2025 pgRouting Developers
+# This file is distributed under the same license as the Workshop FOSS4G Auckland package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
+"Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:44+0000\n"
+"POT-Creation-Date: 2025-09-30 17:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgid "|pgrouting-web| adds routing functionality to |postgis-web|."
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:15
-msgid "Please see the :doc:`contents <../index>` for full content of FOSS4G Belém workshop. This workshop covers two levels for using pgRouting: `Basic`_ and `Advanced`_."
+msgid "Please see the :doc:`contents <../index>` for full content of FOSS4G Auckland workshop. This workshop covers two levels for using pgRouting: `Basic`_ and `Advanced`_."
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:20
@@ -33,7 +33,7 @@ msgid "Basic"
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:22
-msgid "will demonstrate the routing functionality by providing examples using |osm-web| road network data from Belém. Covering topics from how to prepare the data, making routing queries, understanding the results, up to writing a custom 'plpgsql' function that can be integrated with other FOSS tools."
+msgid "will demonstrate the routing functionality by providing examples using |osm-web| road network data from Auckland. Covering topics from how to prepare the data, making routing queries, understanding the results, up to writing a custom 'plpgsql' function that can be integrated with other FOSS tools."
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:28
@@ -108,7 +108,7 @@ msgid "Paragon Corporation"
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:70
-msgid "Developers & presenters of FOSS4G Belém workshop:"
+msgid "Developers & presenters of FOSS4G Auckland workshop:"
 msgstr ""
 
 #: ../../build/docs/general-intro/introduction.rst:71


### PR DESCRIPTION


Changes proposed in this pull request:
- Pumps up version to v3.1.0-dev
- Use Auckland data

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated workshop content to Auckland 2025: city, landmarks, coordinates, routes, data snapshot (Jun 2025), and refreshed versioning/branding.

* **Documentation**
  * Revised guides, examples, and narrative text to the Auckland context; updated dates and sample coordinates; fixed an internal documentation link.
  * Refreshed English translations and POT templates; metadata and generator info updated.

* **Chores**
  * CI now installs gettext for localization.
  * Simplified build scripts by removing several explicit file dependency declarations and minor formatting fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->