### PR TITLE
Fixing auckland data to match OSGeoLive data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ option(PGR_WORKSHOP_VERBOSE_DEBUG
 #---------------------------------------------
 # CONFIGURATION
 #---------------------------------------------
-set(PGR_WORKSHOP_CITY_FILE "auckland_NZ")
+set(PGR_WORKSHOP_CITY_FILE "AUCKLAND_NZ")
 
 # https://github.com/OSGeo/OSGeoLive/blob/master/bin/install_osm.sh
 # around line 117

--- a/locale/en/LC_MESSAGES/basic/data.po
+++ b/locale/en/LC_MESSAGES/basic/data.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 17:36+0000\n"
+"POT-Creation-Date: 2025-11-28 19:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -156,7 +156,7 @@ msgid "the osm2pgrouting default ``mapconfig.xml`` configuration file is used"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:115
-msgid "and the ``~/Desktop/workshop/auckland_NZ.osm`` data"
+msgid "and the ``~/Desktop/workshop/AUCKLAND_NZ.osm`` data"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:116

--- a/locale/en/LC_MESSAGES/basic/pedestrian.po
+++ b/locale/en/LC_MESSAGES/basic/pedestrian.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-04 19:49+0000\n"
+"POT-Creation-Date: 2025-11-28 19:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -339,19 +339,19 @@ msgid "Inspecting the results, looking for totals (edge = -1):"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:3
-msgid "From 10840 to vertex 10928 takes 9.82 minutes (seq = 134)"
+msgid "From 10832 to vertex 11046 takes 9.82 minutes (seq = 134)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:5
-msgid "From 10840 to vertex 12777 takes 10.85 minutes (seq = 185)"
+msgid "From 10832 to vertex 14824 takes 10.85 minutes (seq = 185)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:7
-msgid "From 936 to vertex 10928 takes 9.20 minutes (seq = 50)"
+msgid "From 593 to vertex 11046 takes 9.07 minutes (seq = 50)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:9
-msgid "From 936 to vertex 12777 takes 9.04 minutes (seq = 85)"
+msgid "From 593 to vertex 14824 takes 9.04 minutes (seq = 85)"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:248

--- a/locale/pot/basic/data.pot
+++ b/locale/pot/basic/data.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 17:36+0000\n"
+"POT-Creation-Date: 2025-11-28 19:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -129,7 +129,7 @@ msgid "the osm2pgrouting default ``mapconfig.xml`` configuration file is used"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:115
-msgid "and the ``~/Desktop/workshop/auckland_NZ.osm`` data"
+msgid "and the ``~/Desktop/workshop/AUCKLAND_NZ.osm`` data"
 msgstr ""
 
 #: ../../build/docs/basic/data.rst:116

--- a/locale/pot/basic/pedestrian.pot
+++ b/locale/pot/basic/pedestrian.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-04 19:49+0000\n"
+"POT-Creation-Date: 2025-11-28 19:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -291,19 +291,19 @@ msgid "Inspecting the results, looking for totals (edge = -1):"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:3
-msgid "From 10840 to vertex 10928 takes 9.82 minutes (seq = 134)"
+msgid "From 10832 to vertex 11046 takes 9.82 minutes (seq = 134)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:5
-msgid "From 10840 to vertex 12777 takes 10.85 minutes (seq = 185)"
+msgid "From 10832 to vertex 14824 takes 10.85 minutes (seq = 185)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:7
-msgid "From 936 to vertex 10928 takes 9.20 minutes (seq = 50)"
+msgid "From 593 to vertex 11046 takes 9.07 minutes (seq = 50)"
 msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:9
-msgid "From 936 to vertex 12777 takes 9.04 minutes (seq = 85)"
+msgid "From 593 to vertex 14824 takes 9.04 minutes (seq = 85)"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:248


### PR DESCRIPTION
Fixes #266 
During the FOSS4G 2025 it was noticed that the workshop did not match the data on OSGeoLive 17

Changes proposed in this pull request:
- The Files on `download` were updated
- The correct file name is` AUCKLAND_NZ`


@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated data file references in workshop documentation.
  * Refreshed example routing paths and timing information in pedestrian workshop guides.

* **Chores**
  * Updated localization metadata and translation strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->