### PR TITLE
docs: fix incorrect table names in the workshop documentation

### DIFF
--- a/docs/advanced/chapter-12.rst
+++ b/docs/advanced/chapter-12.rst
@@ -99,7 +99,7 @@ This function:
 * Assigns a ``source`` and a ``target`` identifiers to each road link
 * It can logically "snap" nearby vertices within a certain tolerance by
   assigning the same identifier.
-* Creates a vertices table related to it.
+* Creates a ways_vertices_pgr table related to it.
 * Creates the basic indices.
 
 .. code-block:: sql
@@ -150,7 +150,7 @@ To verify that there is a basic `Routing Network Topology`:
 
   \d planet_osm_roads
 
-Also a new table containing the vertices information was created:
+Also a new table containing the ways_vertices_pgr information was created:
 
 ::
 

--- a/docs/basic/graphs.rst
+++ b/docs/basic/graphs.rst
@@ -140,12 +140,12 @@ a graph.
 Description of the function can be found in `pgr_extractVertices
 <https://docs.pgrouting.org/latest/en/pgr_extractVertices.html>`__
 
-Exercise 1: Create a vertices table
+Exercise 1: Create a ways_vertices_pgr table
 -------------------------------------------------------------------------------
 
 .. rubric:: Problem
 
-Create the vertices table corresponding to the edges in ``ways``.
+Create the ways_vertices_pgr table corresponding to the edges in ``ways``.
 
 .. rubric:: Solution
 
@@ -167,7 +167,7 @@ Create the vertices table corresponding to the edges in ``ways``.
 
   .. literalinclude:: ../scripts/basic/graphs/create_vertices.txt
 
-Reviewing the description of the vertices table
+Reviewing the description of the ways_vertices_pgr table
 
 .. literalinclude:: ../scripts/basic/graphs/graphs.sql
   :start-after: vertices_description.txt
@@ -177,7 +177,7 @@ Reviewing the description of the vertices table
 
   .. literalinclude:: ../scripts/basic/graphs/vertices_description.txt
 
-Inspecting the information on the vertices table
+Inspecting the information on the ways_vertices_pgr table
 
 .. literalinclude:: ../scripts/basic/graphs/graphs.sql
   :language: sql
@@ -189,12 +189,12 @@ Inspecting the information on the vertices table
   .. literalinclude:: ../scripts/basic/graphs/selected_rows.txt
 
 
-Exercise 2: Fill up other columns in the vertices table
+Exercise 2: Fill up other columns in the ways_vertices_pgr table
 -------------------------------------------------------------------------------
 
 .. rubric:: Problem
 
-Fill up geometry information on the vertices table.
+Fill up geometry information on the ways_vertices_pgr table.
 
 .. rubric:: Solution
 
@@ -211,7 +211,7 @@ Count the number of rows that need to be filled up.
 .. rubric:: Update the ``geom`` and ``osm_id`` columns
 
 * The update based on the ``source`` column from ``ways`` table and the ``id``
-  column of the vertices table.
+  column of the ways_vertices_pgr table.
 * To update ``geom`` column, use the start point of the geometry on the ``ways``
   table.
 * Use the ``source_osm`` value to fill up ``osm_id`` column.
@@ -227,7 +227,7 @@ Count the number of rows that need to be filled up.
 
   .. literalinclude:: ../scripts/basic/graphs/fill_columns_2.txt
 
-Not expecting to be done due to the fact that some vertices are dead ends.
+Not expecting to be done due to the fact that some ways_vertices_pgr are dead ends.
 
 .. literalinclude:: ../scripts/basic/graphs/graphs.sql
   :language: sql
@@ -241,7 +241,7 @@ Not expecting to be done due to the fact that some vertices are dead ends.
 .. rubric:: Continue update the ``geom`` and ``osm_id`` columns
 
 * The update based on the ``target`` column from ``ways`` table and the ``id``
-  column of the vertices table.
+  column of the ways_vertices_pgr table.
 * To update ``geom`` column, use the end point of the geometry on the ``ways``
   table.
 * Use the ``target_osm`` value to fill up ``osm_id`` column.
@@ -305,7 +305,7 @@ Description of the function can be found in `pgr_connectedComponents
 <https://docs.pgrouting.org/latest/en/pgr_connectedComponents.html>`__
 
 
-Exercise 3: Set components on edges and vertices tables
+Exercise 3: Set components on edges and ways_vertices_pgr tables
 -------------------------------------------------------------------------------
 
 .. rubric:: Problem
@@ -325,9 +325,9 @@ Create additional columns on the edges tables.
 
   .. literalinclude:: ../scripts/basic/graphs/set_components1.txt
 
-.. rubric:: Use the ``pgr_connectedComponents`` to fill up the vertices table.
+.. rubric:: Use the ``pgr_connectedComponents`` to fill up the ways_vertices_pgr table.
 
-- Use the results to store the component numbers on the vertices table.
+- Use the results to store the component numbers on the ways_vertices_pgr table.
 
 .. literalinclude:: ../scripts/basic/graphs/graphs.sql
   :language: sql
@@ -358,14 +358,14 @@ Exercise 4: Inspect the components
 
 Answer the following questions:
 
-#. How many components are in the vertices table?
+#. How many components are in the ways_vertices_pgr table?
 #. How many components are in the edges table?
 #. List the 10 components with more edges.
 #. Get the component with the maximum number of edges.
 
 .. rubric:: Solution
 
-.. rubric:: 1. How many components are in the vertices table?
+.. rubric:: 1. How many components are in the ways_vertices_pgr table?
 
 Count the distinct components.
 

--- a/docs/interactions/code/QGISfunctions.sql
+++ b/docs/interactions/code/QGISfunctions.sql
@@ -439,17 +439,17 @@ FROM wrk_dijkstra('vehicle_net',  252643343, 302057309);
 
 
 DROP VIEW IF EXISTS ch8_e1 ; CREATE VIEW ch8_e1 AS 
--- Number of vertices in the original graph
+-- Number of ways_vertices_pgr in the original graph
 SELECT count(*) FROM ways_vertices_pgr;
 
--- Number of vertices in the vehicles_net graph
+-- Number of ways_vertices_pgr in the vehicles_net graph
 SELECT count(*) FROM ways_vertices_pgr
 WHERE id IN (
     SELECT source FROM vehicle_net
     UNION
     SELECT target FROM vehicle_net);
 
--- Number of vertices in the little_net graph
+-- Number of ways_vertices_pgr in the little_net graph
 SELECT count(*) FROM ways_vertices_pgr
 WHERE id IN (
     SELECT source FROM little_net
@@ -464,26 +464,26 @@ SELECT osm_id FROM ways_vertices_pgr
 
 -- Closest osm_id in the vehicle_net graph
 WITH
-vertices AS (
+ways_vertices_pgr AS (
     SELECT * FROM ways_vertices_pgr
     WHERE id IN (
         SELECT source FROM vehicle_net
         UNION
         SELECT target FROM vehicle_net)
 )
-SELECT osm_id FROM vertices
+SELECT osm_id FROM ways_vertices_pgr
     ORDER BY the_geom <-> ST_SetSRID(ST_Point(39.291852, -6.811437), 4326) LIMIT 1;
 
 -- Closest osm_id in the little_net graph
 WITH
-vertices AS (
+ways_vertices_pgr AS (
     SELECT * FROM ways_vertices_pgr
     WHERE id IN (
         SELECT source FROM little_net
         UNION
         SELECT target FROM little_net)
 )
-SELECT osm_id FROM vertices
+SELECT osm_id FROM ways_vertices_pgr
     ORDER BY the_geom <-> ST_SetSRID(ST_Point(39.291852, -6.811437), 4326) LIMIT 1;
 
 
@@ -510,7 +510,7 @@ BEGIN
     final_query :=
         FORMAT( $$
             WITH
-            vertices AS (
+            ways_vertices_pgr AS (
                 SELECT * FROM ways_vertices_pgr
                 WHERE id IN (
                     SELECT source FROM %1$I
@@ -522,10 +522,10 @@ BEGIN
                 FROM wrk_dijkstra(
                     '%1$I',
                     -- source
-                    (SELECT osm_id FROM vertices
+                    (SELECT osm_id FROM ways_vertices_pgr
                         ORDER BY the_geom <-> ST_SetSRID(ST_Point(%2$s, %3$s), 4326) LIMIT 1),
                     -- target
-                    (SELECT osm_id FROM vertices
+                    (SELECT osm_id FROM ways_vertices_pgr
                         ORDER BY the_geom <-> ST_SetSRID(ST_Point(%4$s, %5$s), 4326) LIMIT 1))
             )
             SELECT

--- a/docs/interactions/code/functions.sql
+++ b/docs/interactions/code/functions.sql
@@ -439,17 +439,17 @@ FROM wrk_dijkstra('vehicle_net',  252643343, 302057309);
 
 
 
--- Number of vertices in the original graph
+-- Number of ways_vertices_pgr in the original graph
 SELECT count(*) FROM ways_vertices_pgr;
 
--- Number of vertices in the vehicles_net graph
+-- Number of ways_vertices_pgr in the vehicles_net graph
 SELECT count(*) FROM ways_vertices_pgr
 WHERE id IN (
     SELECT source FROM vehicle_net
     UNION
     SELECT target FROM vehicle_net);
 
--- Number of vertices in the little_net graph
+-- Number of ways_vertices_pgr in the little_net graph
 SELECT count(*) FROM ways_vertices_pgr
 WHERE id IN (
     SELECT source FROM little_net
@@ -464,26 +464,26 @@ SELECT osm_id FROM ways_vertices_pgr
 
 -- Closest osm_id in the vehicle_net graph
 WITH
-vertices AS (
+ways_vertices_pgr AS (
     SELECT * FROM ways_vertices_pgr
     WHERE id IN (
         SELECT source FROM vehicle_net
         UNION
         SELECT target FROM vehicle_net)
 )
-SELECT osm_id FROM vertices
+SELECT osm_id FROM ways_vertices_pgr
     ORDER BY the_geom <-> ST_SetSRID(ST_Point(39.291852, -6.811437), 4326) LIMIT 1;
 
 -- Closest osm_id in the little_net graph
 WITH
-vertices AS (
+ways_vertices_pgr AS (
     SELECT * FROM ways_vertices_pgr
     WHERE id IN (
         SELECT source FROM little_net
         UNION
         SELECT target FROM little_net)
 )
-SELECT osm_id FROM vertices
+SELECT osm_id FROM ways_vertices_pgr
     ORDER BY the_geom <-> ST_SetSRID(ST_Point(39.291852, -6.811437), 4326) LIMIT 1;
 
 
@@ -510,7 +510,7 @@ BEGIN
     final_query :=
         FORMAT( $$
             WITH
-            vertices AS (
+            ways_vertices_pgr AS (
                 SELECT * FROM ways_vertices_pgr
                 WHERE id IN (
                     SELECT source FROM %1$I
@@ -522,10 +522,10 @@ BEGIN
                 FROM wrk_dijkstra(
                     '%1$I',
                     -- source
-                    (SELECT osm_id FROM vertices
+                    (SELECT osm_id FROM ways_vertices_pgr
                         ORDER BY the_geom <-> ST_SetSRID(ST_Point(%2$s, %3$s), 4326) LIMIT 1),
                     -- target
-                    (SELECT osm_id FROM vertices
+                    (SELECT osm_id FROM ways_vertices_pgr
                         ORDER BY the_geom <-> ST_SetSRID(ST_Point(%4$s, %5$s), 4326) LIMIT 1))
             )
             SELECT

--- a/docs/scripts/basic/graphs/graphs.sql
+++ b/docs/scripts/basic/graphs/graphs.sql
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS vertices CASCADE;
+DROP TABLE IF EXISTS ways_vertices_pgr CASCADE;
 DROP VIEW IF EXISTS vehicle_net CASCADE;
 DROP VIEW IF EXISTS taxi_net CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS walk_net CASCADE;
@@ -20,37 +20,37 @@ ORDER BY tag_id;
 \o create_vertices.txt
 
 SELECT id, in_edges, out_edges, x, y, NULL::BIGINT osm_id, NULL::BIGINT component, geom
-INTO vertices
+INTO ways_vertices_pgr
 FROM pgr_extractVertices(
   'SELECT gid AS id, source, target
   FROM ways ORDER BY id');
 
 \o vertices_description.txt
-\dS+ vertices
+\dS+ ways_vertices_pgr
 \o selected_rows.txt
-SELECT * FROM vertices Limit 10;
+SELECT * FROM ways_vertices_pgr Limit 10;
 
 \o fill_columns_1.txt
-SELECT count(*) FROM vertices WHERE geom IS NULL;
+SELECT count(*) FROM ways_vertices_pgr WHERE geom IS NULL;
 \o fill_columns_2.txt
-UPDATE vertices SET (geom, osm_id) = (ST_startPoint(the_geom), source_osm)
+UPDATE ways_vertices_pgr SET (geom, osm_id) = (ST_startPoint(the_geom), source_osm)
 FROM ways WHERE source = id;
 \o fill_columns_3.txt
-SELECT count(*) FROM vertices WHERE geom IS NULL;
+SELECT count(*) FROM ways_vertices_pgr WHERE geom IS NULL;
 \o fill_columns_4.txt
-UPDATE vertices SET (geom, osm_id) = (ST_endPoint(the_geom), target_osm)
+UPDATE ways_vertices_pgr SET (geom, osm_id) = (ST_endPoint(the_geom), target_osm)
 FROM ways WHERE geom IS NULL AND target = id;
 \o fill_columns_5.txt
-SELECT count(*) FROM vertices WHERE geom IS NULL;
+SELECT count(*) FROM ways_vertices_pgr WHERE geom IS NULL;
 \o fill_columns_6.txt
-UPDATE vertices set (x,y) = (ST_X(geom), ST_Y(geom));
+UPDATE ways_vertices_pgr set (x,y) = (ST_X(geom), ST_Y(geom));
 
 
 \o set_components1.txt
 ALTER TABLE ways ADD COLUMN component BIGINT;
 
 \o set_components2.txt
-UPDATE vertices AS v SET component = c.component
+UPDATE ways_vertices_pgr AS v SET component = c.component
 FROM (
   SELECT seq, component, node
   FROM pgr_connectedComponents(
@@ -60,11 +60,11 @@ WHERE v.id = c.node;
 \o set_components3.txt
 
 UPDATE ways SET component = v.component
-FROM (SELECT id, component FROM vertices) AS v
+FROM (SELECT id, component FROM ways_vertices_pgr) AS v
 WHERE source = v.id;
 
 \o see_components1.txt
-SELECT count(DISTINCT component) FROM vertices;
+SELECT count(DISTINCT component) FROM ways_vertices_pgr;
 \o see_components2.txt
 SELECT count(DISTINCT component) FROM ways;
 \o see_components3.txt

--- a/docs/scripts/basic/graphs/images.sql
+++ b/docs/scripts/basic/graphs/images.sql
@@ -4,7 +4,7 @@ SELECT row_number() over() as gid, ST_makeline(v1.geom, v2.geom) AS geom,
 '('||start_vid||', '||end_vid||') t= ' || round(agg_cost::NUMERIC, 2) AS name
 INTO costMatrix_png
 FROM pgr_dijkstraCostMatrix(
-  'SELECT * FROM vehicle_net',
+  'SELECT * FROM ways',
   ARRAY[@ID_1@, @ID_2@, @ID_3@, @ID_4@, @ID_5@])
 JOIN ways_vertices_pgr v1 ON (start_vid=v1.id)
 JOIN ways_vertices_pgr v2 ON (end_vid=v2.id);

--- a/docs/scripts/basic/graphs/images.sql
+++ b/docs/scripts/basic/graphs/images.sql
@@ -6,5 +6,5 @@ INTO costMatrix_png
 FROM pgr_dijkstraCostMatrix(
   'SELECT * FROM vehicle_net',
   ARRAY[@ID_1@, @ID_2@, @ID_3@, @ID_4@, @ID_5@])
-JOIN vertices v1 ON (start_vid=v1.id)
-JOIN vertices v2 ON (end_vid=v2.id);
+JOIN ways_vertices_pgr v1 ON (start_vid=v1.id)
+JOIN ways_vertices_pgr v2 ON (end_vid=v2.id);

--- a/docs/scripts/basic/pedestrian/images.sql
+++ b/docs/scripts/basic/pedestrian/images.sql
@@ -16,62 +16,62 @@ WITH dijkstra AS (
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target,
     length AS cost
-    FROM walk_net',
+    FROM ways',
   @ID_1@,
   @ID_3@,
   directed := false)
 )
-SELECT seq, start_vid, end_vid, geom AS geom FROM dijkstra JOIN walk_net ON(edge = id);
+SELECT seq, start_vid, end_vid, geom AS geom FROM dijkstra JOIN ways ON(edge = id);
 
 CREATE OR REPLACE VIEW pedestrian_many_to_one AS
 WITH dijkstra AS (
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target,
     length/1000 AS cost
-    FROM walk_net',
+    FROM ways',
   ARRAY[@ID_1@, @ID_2@],
   @ID_3@,
   directed := false)
 )
-SELECT seq, start_vid, end_vid, geom AS geom FROM dijkstra JOIN walk_net ON(edge = id);
+SELECT seq, start_vid, end_vid, geom AS geom FROM dijkstra JOIN ways ON(edge = id);
 
 CREATE OR REPLACE VIEW pedestrian_one_to_many AS
 WITH dijkstra AS (
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target,
     cost
-    FROM walk_net',
+    FROM ways',
   @ID_3@,
   ARRAY[@ID_1@, @ID_2@],
   directed := false)
 )
-SELECT seq, start_vid, end_vid, geom AS geom FROM dijkstra JOIN walk_net ON(edge = id);
+SELECT seq, start_vid, end_vid, geom AS geom FROM dijkstra JOIN ways ON(edge = id);
 
 CREATE OR REPLACE VIEW pedestrian_many_to_many AS
 WITH dijkstra AS (
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target,
     length / 1.3 / 60 AS cost
-    FROM walk_net',
+    FROM ways',
   ARRAY[@ID_1@, @ID_2@],
   ARRAY[@ID_4@, @ID_5@],
   directed := false)
 )
-SELECT seq, start_vid, end_vid, geom AS geom FROM dijkstra JOIN walk_net ON(edge = id);
+SELECT seq, start_vid, end_vid, geom AS geom FROM dijkstra JOIN ways ON(edge = id);
 
 CREATE OR REPLACE VIEW pedestrian_combinations AS
 WITH dijkstra AS (
  SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target,
     length / 1.3 / 60 AS cost
-    FROM walk_net',
+    FROM ways',
   'SELECT * FROM (VALUES
     (@ID_1@, @ID_4@),
     (@ID_2@, @ID_5@))
   AS combinations (source, target)',
   directed := false)
 )
-SELECT seq, start_vid, end_vid, geom AS geom FROM dijkstra JOIN walk_net ON(edge = id);
+SELECT seq, start_vid, end_vid, geom AS geom FROM dijkstra JOIN ways ON(edge = id);
 
 CREATE OR REPLACE VIEW pedestrian_dijkstraCost AS
 WITH dijkstra AS (
@@ -79,7 +79,7 @@ SELECT start_vid, end_vid, round(agg_cost::numeric,2) AS agg_cost
 FROM pgr_dijkstraCost(
   'SELECT id, source, target,
     length / 1.3 / 60 AS cost
-    FROM walk_net',
+    FROM ways',
   ARRAY[@ID_1@, @ID_2@],
   ARRAY[@ID_4@, @ID_5@],
   directed := false)

--- a/docs/scripts/basic/pedestrian/images.sql
+++ b/docs/scripts/basic/pedestrian/images.sql
@@ -7,7 +7,7 @@ CASE
   WHEN osm_id = @OSMID_4@ THEN '@PLACE_4@'
   WHEN osm_id = @OSMID_5@ THEN '@PLACE_5@'
 END AS name
-FROM vertices
+FROM ways_vertices_pgr
 WHERE osm_id IN (@OSMID_1@, @OSMID_2@, @OSMID_3@, @OSMID_4@, @OSMID_5@)
 ORDER BY osm_id;
 
@@ -85,5 +85,5 @@ FROM pgr_dijkstraCost(
   directed := false)
 )
 SELECT row_number() over() AS gid, start_vid, end_vid, agg_cost, ST_MakeLine(v1.geom, v2.geom) AS geom FROM dijkstra
-JOIN vertices AS v1 ON (start_vid = v1.id)
-JOIN vertices AS v2 ON (end_vid = v2.id);
+JOIN ways_vertices_pgr AS v1 ON (start_vid = v1.id)
+JOIN ways_vertices_pgr AS v2 ON (end_vid = v2.id);

--- a/docs/scripts/basic/pedestrian/pedestrian.sql
+++ b/docs/scripts/basic/pedestrian/pedestrian.sql
@@ -1,6 +1,6 @@
 \o get_id.txt
 
-SELECT osm_id, id FROM vertices
+SELECT osm_id, id FROM ways_vertices_pgr
 WHERE osm_id IN (@OSMID_1@, @OSMID_2@, @OSMID_3@, @OSMID_4@, @OSMID_5@)
 ORDER BY osm_id;
 

--- a/docs/scripts/basic/pedestrian/pedestrian.sql
+++ b/docs/scripts/basic/pedestrian/pedestrian.sql
@@ -9,7 +9,7 @@ ORDER BY osm_id;
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target,
     length AS cost
-    FROM walk_net',
+    FROM ways',
   @ID_1@,
   @ID_3@,
   directed := false);
@@ -19,7 +19,7 @@ SELECT * FROM pgr_dijkstra(
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target,
     length/1000 AS cost
-    FROM walk_net',
+    FROM ways',
   ARRAY[@ID_1@, @ID_2@],
   @ID_3@,
   directed := false);
@@ -29,7 +29,7 @@ SELECT * FROM pgr_dijkstra(
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target,
     cost
-    FROM walk_net',
+    FROM ways',
   @ID_3@,
   ARRAY[@ID_1@, @ID_2@],
   directed := false);
@@ -39,7 +39,7 @@ SELECT * FROM pgr_dijkstra(
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target,
     length / 1.3 / 60 AS cost
-    FROM walk_net',
+    FROM ways',
   ARRAY[@ID_1@, @ID_2@],
   ARRAY[@ID_4@, @ID_5@],
   directed := false);
@@ -49,7 +49,7 @@ SELECT * FROM pgr_dijkstra(
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target,
     length / 1.3 / 60 AS cost
-    FROM walk_net',
+    FROM ways',
   'SELECT * FROM (VALUES
     (@ID_1@, @ID_4@),
     (@ID_2@, @ID_5@))
@@ -61,7 +61,7 @@ SELECT * FROM pgr_dijkstra(
 SELECT * FROM pgr_dijkstraCost(
   'SELECT id, source, target,
     length / 1.3 / 60 AS cost
-    FROM walk_net',
+    FROM ways',
   ARRAY[@ID_1@, @ID_2@],
   ARRAY[@ID_4@, @ID_5@],
   directed := false);
@@ -77,7 +77,7 @@ FROM pgr_dijkstra(
   source,
   target,
   length / 1.3 / 60 AS cost
-  FROM walk_net
+  FROM ways
   ',
   ARRAY[@ID_1@, @ID_2@],
   ARRAY[@ID_4@, @ID_5@],
@@ -90,7 +90,7 @@ FROM pgr_dijkstra(
   source,
   target,
   length / 1.3 / 60 AS cost
-  FROM walk_net
+  FROM ways
   ',
   ARRAY[@ID_1@, @ID_2@],
   ARRAY[@ID_4@, @ID_5@],
@@ -103,7 +103,7 @@ FROM pgr_dijkstra(
   source,
   target,
   length / 1.3 / 60 AS cost
-  FROM walk_net
+  FROM ways
   ',
   ARRAY[@ID_1@, @ID_2@],
   ARRAY[@ID_4@, @ID_5@],
@@ -116,7 +116,7 @@ FROM pgr_dijkstra(
   source,
   target,
   length / 1.3 / 60 AS cost
-  FROM walk_net
+  FROM ways
   ',
   ARRAY[@ID_1@, @ID_2@],
   ARRAY[@ID_4@, @ID_5@],

--- a/docs/scripts/basic/sql_function/images.sql
+++ b/docs/scripts/basic/sql_function/images.sql
@@ -1,9 +1,9 @@
 
 CREATE OR REPLACE VIEW using_vehicle AS
 SELECT *
-FROM wrk_dijkstra('vehicle_net',  @CH7_ID_1@, @CH7_ID_2@);
+FROM wrk_dijkstra('ways',  @CH7_ID_1@, @CH7_ID_2@);
 
 CREATE OR REPLACE VIEW sql_route_geom AS
 SELECT seq, id, geom
-FROM wrk_dijkstra('vehicle_net',  @CH7_ID_1@, @CH7_ID_2@)
-JOIN vehicle_net USING (id);
+FROM wrk_dijkstra('ways',  @CH7_ID_1@, @CH7_ID_2@)
+JOIN ways USING (id);

--- a/docs/scripts/basic/sql_function/sql_function.sql
+++ b/docs/scripts/basic/sql_function/sql_function.sql
@@ -210,4 +210,4 @@ GROUP BY name;
 
 \o using_fn3.txt
 SELECT *
-FROM wrk_dijkstra('walk_net',  @CH7_ID_1@, @CH7_ID_2@);
+FROM wrk_dijkstra('ways',  @CH7_ID_1@, @CH7_ID_2@);

--- a/docs/scripts/basic/sql_function/sql_function.sql
+++ b/docs/scripts/basic/sql_function/sql_function.sql
@@ -20,12 +20,12 @@ FROM (
     'SELECT * FROM ' || $1,
     source, target)
 ) AS results
-LEFT JOIN vehicle_net USING (id)
+LEFT JOIN ways USING (id)
 ORDER BY seq;
 $BODY$
 LANGUAGE SQL;
 
-SELECT * FROM wrk_dijkstra('vehicle_net', @CH7_ID_1@, @CH7_ID_2@);
+SELECT * FROM wrk_dijkstra('ways', @CH7_ID_1@, @CH7_ID_2@);
 
 \o get_read_geom.txt
 
@@ -49,12 +49,12 @@ SELECT
   seq, id, seconds, name, length,
   ST_AsText(geom)
 FROM results
-LEFT JOIN vehicle_net USING (id)
+LEFT JOIN ways USING (id)
 ORDER BY seq;
 $BODY$
 LANGUAGE SQL;
 
-SELECT seq, route_readable FROM wrk_dijkstra('vehicle_net', @CH7_ID_1@, @CH7_ID_2@);
+SELECT seq, route_readable FROM wrk_dijkstra('ways', @CH7_ID_1@, @CH7_ID_2@);
 
 \o get_geom.txt
 
@@ -80,19 +80,19 @@ SELECT
   ST_AsText(geom),
   geom
 FROM results
-LEFT JOIN vehicle_net USING (id)
+LEFT JOIN ways USING (id)
 ORDER BY seq;
 $BODY$
 LANGUAGE SQL;
 
-SELECT seq, route_geom FROM wrk_dijkstra('vehicle_net', @CH7_ID_1@, @CH7_ID_2@);
+SELECT seq, route_geom FROM wrk_dijkstra('ways', @CH7_ID_1@, @CH7_ID_2@);
 
 \o wrong_directionality.txt
 
 WITH
 results AS (
   SELECT seq, id, route_geom
-  FROM wrk_dijkstra('vehicle_net', @CH7_ID_1@, @CH7_ID_2@)
+  FROM wrk_dijkstra('ways', @CH7_ID_1@, @CH7_ID_2@)
 ),
 compare AS (
   SELECT seq, id, lead(seq) over(ORDER BY seq) AS next_seq,
@@ -134,19 +134,19 @@ SELECT
       ELSE ST_Reverse(geom)
   END
 FROM results
-LEFT JOIN vehicle_net USING (id)
+LEFT JOIN ways USING (id)
 ORDER BY seq;
 $BODY$
 LANGUAGE SQL;
 
-SELECT seq, route_readable FROM wrk_dijkstra('vehicle_net', @CH7_ID_1@, @CH7_ID_2@);
+SELECT seq, route_readable FROM wrk_dijkstra('ways', @CH7_ID_1@, @CH7_ID_2@);
 
 \o good_directionality.txt
 
 WITH
 results AS (
   SELECT seq, id, seconds, route_geom
-  FROM wrk_dijkstra('vehicle_net', @CH7_ID_1@, @CH7_ID_2@)
+  FROM wrk_dijkstra('ways', @CH7_ID_1@, @CH7_ID_2@)
 ),
 compare AS (
   SELECT seq, id, lead(route_geom) over(ORDER BY seq) AS next_id,
@@ -188,7 +188,7 @@ additional AS (
         ELSE ST_Reverse(geom)
   END AS geom
   FROM results
-  LEFT JOIN vehicle_net USING (id)
+  LEFT JOIN ways USING (id)
   ORDER BY seq)
 
 SELECT *,
@@ -197,11 +197,11 @@ FROM additional ORDER BY seq;
 $BODY$
 LANGUAGE SQL;
 
-SELECT seq, azimuth FROM wrk_dijkstra('vehicle_net', @CH7_ID_1@, @CH7_ID_2@);
+SELECT seq, azimuth FROM wrk_dijkstra('ways', @CH7_ID_1@, @CH7_ID_2@);
 
 \o using_fn1.txt
 SELECT DISTINCT name
-FROM wrk_dijkstra('vehicle_net',  @CH7_ID_1@, @CH7_ID_2@);
+FROM wrk_dijkstra('ways',  @CH7_ID_1@, @CH7_ID_2@);
 
 \o using_fn2.txt
 SELECT name, sum(seconds)

--- a/docs/scripts/basic/vehicles/images.sql
+++ b/docs/scripts/basic/vehicles/images.sql
@@ -3,22 +3,22 @@ CREATE OR REPLACE VIEW vehicle_route_going_png AS
 WITH dijkstra AS (
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target, cost, reverse_cost
-   FROM vehicle_net',
+   FROM ways',
   @ID_1@, @ID_3@,
   directed := true)
 )
-SELECT seq, start_vid, end_vid, geom FROM dijkstra JOIN vehicle_net ON(edge = id);
+SELECT seq, start_vid, end_vid, geom FROM dijkstra JOIN ways ON(edge = id);
 
 
 CREATE OR REPLACE VIEW vehicle_route_coming_png AS
 WITH dijkstra AS (
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target, cost, reverse_cost
-  FROM vehicle_net',
+  FROM ways',
   @ID_3@, @ID_1@,
   directed := true)
 )
-SELECT seq, start_vid, end_vid, geom FROM dijkstra JOIN vehicle_net ON(edge = id);
+SELECT seq, start_vid, end_vid, geom FROM dijkstra JOIN ways ON(edge = id);
 
 CREATE OR REPLACE VIEW vehicle_time_is_money_png AS
 WITH dijkstra AS (
@@ -39,11 +39,11 @@ SELECT * FROM pgr_dijkstra(
   'SELECT v.id, source, target,
      CASE WHEN cost <= 0 THEN -1 ELSE cost * penalty END AS cost,
      CASE WHEN reverse_cost <= 0 THEN -1 ELSE reverse_cost * penalty END AS reverse_cost
-   FROM vehicle_net AS v JOIN configuration
+   FROM ways AS v JOIN configuration
    USING (tag_id)',
   @ID_3@, @ID_1@)
 )
-SELECT seq, start_vid, end_vid, geom FROM dijkstra JOIN vehicle_net ON(edge = id);
+SELECT seq, start_vid, end_vid, geom FROM dijkstra JOIN ways ON(edge = id);
 
 -- Not including cycleways
 UPDATE configuration SET penalty=-1.0
@@ -67,11 +67,11 @@ SELECT * FROM pgr_dijkstra(
   'SELECT v.id, source, target,
      CASE WHEN cost <= 0 THEN -1 ELSE cost * penalty END AS cost,
      CASE WHEN reverse_cost <= 0 THEN -1 ELSE reverse_cost * penalty END AS reverse_cost
-   FROM vehicle_net AS v JOIN configuration
+   FROM ways AS v JOIN configuration
    USING (tag_id)',
   @ID_3@, @ID_1@)
 )
-SELECT seq, geom AS geom FROM dijkstra JOIN vehicle_net ON(edge = id);
+SELECT seq, geom AS geom FROM dijkstra JOIN ways ON(edge = id);
 
 CREATE OR REPLACE VIEW vehicle_penalty_routes AS
 WITH dijkstra AS (

--- a/docs/scripts/basic/vehicles/vehicles.sql
+++ b/docs/scripts/basic/vehicles/vehicles.sql
@@ -1,12 +1,12 @@
 \o oneway_cost.txt
 
-SELECT count(*) FROM vehicle_net
+SELECT count(*) FROM ways
 WHERE cost < 0;
 
 \o oneway_revc.txt
 
 
-SELECT count(*) FROM vehicle_net
+SELECT count(*) FROM ways
 WHERE reverse_cost < 0;
 
 
@@ -14,7 +14,7 @@ WHERE reverse_cost < 0;
 
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target, cost, reverse_cost
-   FROM vehicle_net',
+   FROM ways',
   @ID_1@, @ID_3@,
   directed := true);
 
@@ -22,7 +22,7 @@ SELECT * FROM pgr_dijkstra(
 
 SELECT * FROM pgr_dijkstra(
   'SELECT id, source, target, cost, reverse_cost
-  FROM vehicle_net',
+  FROM ways',
   @ID_3@, @ID_1@,
   directed := true);
 
@@ -46,7 +46,7 @@ SELECT * FROM pgr_dijkstra(
   'SELECT v.id, source, target,
      CASE WHEN cost <= 0 THEN -1 ELSE cost * penalty END AS cost,
      CASE WHEN reverse_cost <= 0 THEN -1 ELSE reverse_cost * penalty END AS reverse_cost
-   FROM vehicle_net AS v JOIN configuration
+   FROM ways AS v JOIN configuration
    USING (tag_id)',
    @ID_3@, @ID_1@);
 
@@ -74,7 +74,7 @@ SELECT * FROM pgr_dijkstra(
   'SELECT v.id, source, target,
      CASE WHEN cost <= 0 THEN -1 ELSE cost * penalty END AS cost,
      CASE WHEN reverse_cost <= 0 THEN -1 ELSE reverse_cost * penalty END AS reverse_cost
-   FROM vehicle_net AS v JOIN configuration
+   FROM ways AS v JOIN configuration
    USING (tag_id)',
    @ID_3@, @ID_1@);
 
@@ -89,10 +89,10 @@ SELECT * FROM pgr_dijkstra(
       'SELECT v.id, source, target,
          CASE WHEN cost <= 0 THEN -1 ELSE cost * penalty END AS cost,
          CASE WHEN reverse_cost <= 0 THEN -1 ELSE reverse_cost * penalty END AS reverse_cost
-       FROM vehicle_net AS v JOIN configuration
+       FROM ways AS v JOIN configuration
        USING (tag_id)',
       @ID_3@, @ID_1@) ) AS edges_in_route
-  JOIN vehicle_net USING (id)
+  JOIN ways USING (id)
   $$,
   @ID_3@, @ID_1@);
 
@@ -103,7 +103,7 @@ SELECT
   v.id, source, target,
   CASE WHEN cost <= 0 THEN -1 ELSE cost * penalty END AS cost,
   CASE WHEN reverse_cost <= 0 THEN -1 ELSE reverse_cost * penalty END AS reverse_cost
-FROM vehicle_net AS v JOIN configuration
+FROM ways AS v JOIN configuration
 USING (tag_id);
 
 \o using_view.txt
@@ -117,7 +117,7 @@ SELECT * FROM pgr_dijkstra(
       'SELECT id, source, target, cost, reverse_cost
        FROM penalized',
       @ID_3@, @ID_1@) ) AS edges_in_route
-  JOIN vehicle_net USING (id)
+  JOIN ways USING (id)
   $$,
   @ID_3@, @ID_1@);
 

--- a/docs/scripts/basic/withPoints/images.sql
+++ b/docs/scripts/basic/withPoints/images.sql
@@ -11,13 +11,13 @@ FROM the_points;
 DROP TABLE IF EXISTS closest_walk;
 WITH the_closest AS (
 SELECT 1 AS pid, * from pgr_findCloseEdges(
-  'SELECT id, geom from walk_net',
+  'SELECT id, geom from ways',
    ST_SetSRID(ST_Point(@POINT1_LON@, @POINT1_LAT@), 4326) , 0.5)
 
 UNION
 
 SELECT 2 AS pid, * from pgr_findCloseEdges(
-  'SELECT id, geom from walk_net',
+  'SELECT id, geom from ways',
   ST_SetSRID(ST_Point(@POINT2_LON@, @POINT2_LAT@), 4326) , 0.5)
 )
 SELECT * INTO closest_walk FROM the_closest;
@@ -37,6 +37,6 @@ SELECT * FROM wrk_withPoints(
 CREATE OR REPLACE VIEW using_walk AS
 SELECT *
 FROM wrk_withPoints(
-  'walk_net',
+  'ways',
   @POINT1_LAT@, @POINT1_LON@,
   @POINT2_LAT@, @POINT2_LON@);

--- a/docs/scripts/basic/withPoints/images.sql
+++ b/docs/scripts/basic/withPoints/images.sql
@@ -24,7 +24,7 @@ SELECT * INTO closest_walk FROM the_closest;
 
 CREATE OR REPLACE VIEW using_vehicle AS
 SELECT * FROM wrk_withPoints(
-  'vehicle_net',
+  'ways',
   @POINT1_LAT@, @POINT1_LON@,
   @POINT2_LAT@, @POINT2_LON@);
 

--- a/docs/scripts/basic/withPoints/withPoints.sql
+++ b/docs/scripts/basic/withPoints/withPoints.sql
@@ -1,27 +1,27 @@
 \o closestedges.txt
 
 SELECT 1 AS pid, * from pgr_findCloseEdges(
-  'SELECT id, geom from vehicle_net',
+  'SELECT id, geom from ways',
    ST_SetSRID(ST_Point(@POINT1_LON@, @POINT1_LAT@), 4326) , 0.5)
 
 UNION
 
 SELECT 2 AS pid, * from pgr_findCloseEdges(
-  'SELECT id, geom from vehicle_net',
+  'SELECT id, geom from ways',
   ST_SetSRID(ST_Point(@POINT2_LON@, @POINT2_LAT@), 4326) , 0.5);
 
 
 \o route_withPoints.txt
 
 SELECT * FROM pgr_withPoints(
-  'SELECT id, source, target, cost, reverse_cost from vehicle_net',
+  'SELECT id, source, target, cost, reverse_cost from ways',
   $$
   SELECT 2 AS pid, * from pgr_findCloseEdges(
-    'SELECT id, geom from vehicle_net',
+    'SELECT id, geom from ways',
     ST_SetSRID(ST_Point(@POINT1_LON@,  @POINT1_LAT@), 4326), 0.5)
   UNION
   SELECT 1 AS pid, * from pgr_findCloseEdges(
-    'SELECT id, geom from vehicle_net',
+    'SELECT id, geom from ways',
      ST_SetSRID(ST_Point(@POINT2_LON@,  @POINT2_LAT@), 4326), 0.5)
   $$,
   -1, -2);
@@ -118,7 +118,7 @@ LANGUAGE plpgsql;
 
 SELECT DISTINCT name
 FROM wrk_withPoints(
-  'vehicle_net',
+  'ways',
   @POINT1_LAT@, @POINT1_LON@,
   @POINT2_LAT@, @POINT2_LON@);
 

--- a/docs/scripts/basic/withPoints/withPoints.sql
+++ b/docs/scripts/basic/withPoints/withPoints.sql
@@ -136,7 +136,7 @@ FROM wrk_withPoints(
 SELECT *
 INTO example
 FROM wrk_withPoints(
-  'walk_net',
+  'ways',
   @POINT1_LAT@, @POINT1_LON@,
   @POINT2_LAT@, @POINT2_LON@);
 

--- a/docs/un_sdg/sdg11-cities.rst
+++ b/docs/un_sdg/sdg11-cities.rst
@@ -247,7 +247,7 @@ This helps in storing the component id in the ``waterways_ways_vertices_pgr`` ta
 Next query uses this output and stores the component id in the waterways_ways
 (edges) table. Follow the steps given below to complete this task.
 
-.. rubric:: Create a vertices table.
+.. rubric:: Create a ways_vertices_pgr table.
 
 .. literalinclude:: ../scripts/un_sdg/sdg11/all_exercises_sdg11.sql
     :start-after: only_connected1.txt
@@ -269,7 +269,7 @@ Next query uses this output and stores the component id in the waterways_ways
 
   .. literalinclude:: ../scripts/un_sdg/sdg11/only_connected2.txt
 
-.. rubric:: Add a ``component`` column on the edges and vertices tables.
+.. rubric:: Add a ``component`` column on the edges and ways_vertices_pgr tables.
 
 .. literalinclude:: ../scripts/un_sdg/sdg11/all_exercises_sdg11.sql
     :start-after: only_connected3.txt
@@ -280,7 +280,7 @@ Next query uses this output and stores the component id in the waterways_ways
 
   .. literalinclude:: ../scripts/un_sdg/sdg11/only_connected3.txt
 
-.. rubric:: Fill up the ``component`` column on the vertices table.
+.. rubric:: Fill up the ``component`` column on the ways_vertices_pgr table.
 
 .. literalinclude:: ../scripts/un_sdg/sdg11/all_exercises_sdg11.sql
     :start-after: only_connected4.txt

--- a/docs/un_sdg/sdg3-health.rst
+++ b/docs/un_sdg/sdg3-health.rst
@@ -426,7 +426,7 @@ pgRouting functions, discussed on :doc:`../basic/graphs`, will be used:
 * ``pgr_extractVertices``
 * ``pgr_connectedComponents``
 
-.. rubric:: Create a vertices table.
+.. rubric:: Create a ways_vertices_pgr table.
 
 .. literalinclude:: ../scripts/un_sdg/sdg3/all_exercises_sdg3.sql
     :start-after: only_connected1.txt
@@ -448,7 +448,7 @@ pgRouting functions, discussed on :doc:`../basic/graphs`, will be used:
 
   .. literalinclude:: ../scripts/un_sdg/sdg3/only_connected2.txt
 
-.. rubric:: Add a ``component`` column on the edges and vertices tables.
+.. rubric:: Add a ``component`` column on the edges and ways_vertices_pgr tables.
 
 .. literalinclude:: ../scripts/un_sdg/sdg3/all_exercises_sdg3.sql
     :start-after: only_connected3.txt
@@ -459,7 +459,7 @@ pgRouting functions, discussed on :doc:`../basic/graphs`, will be used:
 
   .. literalinclude:: ../scripts/un_sdg/sdg3/only_connected3.txt
 
-.. rubric:: Fill up the ``component`` column on the vertices table.
+.. rubric:: Fill up the ``component`` column on the ways_vertices_pgr table.
 
 .. literalinclude:: ../scripts/un_sdg/sdg3/all_exercises_sdg3.sql
     :start-after: only_connected4.txt
@@ -503,7 +503,7 @@ pgRouting functions, discussed on :doc:`../basic/graphs`, will be used:
 
   .. literalinclude:: ../scripts/un_sdg/sdg3/only_connected7.txt
 
-.. rubric:: Delete vertices not belonging to the most connected component.
+.. rubric:: Delete ways_vertices_pgr not belonging to the most connected component.
 
 .. literalinclude:: ../scripts/un_sdg/sdg3/all_exercises_sdg3.sql
     :start-after: only_connected8.txt
@@ -546,7 +546,7 @@ can be found at this link for more information.
 
 Exercise 13: Find the closest road vertex
 --------------------------------------------------------------------------------
-There are multiple road vertices near the hospital. Create a function to find
+There are multiple road ways_vertices_pgr near the hospital. Create a function to find
 the geographically closest road vertex. ``closest_vertex`` function takes geometry
 of other table as input and gives the gid of the closest vertex as output by
 comparing ``geom`` of both the tables.

--- a/docs/un_sdg/sdg7-energy.rst
+++ b/docs/un_sdg/sdg7-energy.rst
@@ -102,7 +102,7 @@ pgRouting functions, discussed on :doc:`../basic/graphs`, will be used:
 * ``pgr_extractVertices``
 * ``pgr_connectedComponents``
 
-.. rubric:: Create a vertices table.
+.. rubric:: Create a ways_vertices_pgr table.
 
 .. literalinclude:: ../scripts/un_sdg/sdg7/all_exercises_sdg7.sql
     :start-after: only_connected1.txt
@@ -124,7 +124,7 @@ pgRouting functions, discussed on :doc:`../basic/graphs`, will be used:
 
   .. literalinclude:: ../scripts/un_sdg/sdg7/only_connected2.txt
 
-.. rubric:: Add a ``component`` column on the edges and vertices tables.
+.. rubric:: Add a ``component`` column on the edges and ways_vertices_pgr tables.
 
 .. literalinclude:: ../scripts/un_sdg/sdg7/all_exercises_sdg7.sql
     :start-after: only_connected3.txt
@@ -135,7 +135,7 @@ pgRouting functions, discussed on :doc:`../basic/graphs`, will be used:
 
   .. literalinclude:: ../scripts/un_sdg/sdg7/only_connected3.txt
 
-.. rubric:: Fill up the ``component`` column on the vertices table.
+.. rubric:: Fill up the ``component`` column on the ways_vertices_pgr table.
 
 .. literalinclude:: ../scripts/un_sdg/sdg7/all_exercises_sdg7.sql
     :start-after: only_connected4.txt
@@ -179,7 +179,7 @@ pgRouting functions, discussed on :doc:`../basic/graphs`, will be used:
 
   .. literalinclude:: ../scripts/un_sdg/sdg3/only_connected7.txt
 
-.. rubric:: Delete vertices not belonging to the most connected component.
+.. rubric:: Delete ways_vertices_pgr not belonging to the most connected component.
 
 .. literalinclude:: ../scripts/un_sdg/sdg7/all_exercises_sdg7.sql
     :start-after: only_connected8.txt

--- a/locale/en/LC_MESSAGES/advanced/chapter-12.po
+++ b/locale/en/LC_MESSAGES/advanced/chapter-12.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:44+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: ../../build/docs/advanced/chapter-12.rst:11
 msgid "Create a Network Topology"
@@ -26,13 +26,13 @@ msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:17
 msgid ""
-":doc:`osm2pgrouting <../appendix/appendix-3>` is a convenient tool, and "
-"its focus to work on OpenStreetMap data. There are several cases where "
-":doc:`osm2pgrouting <../appendix/appendix-3>` can't be used. Some network"
-" data already comes with a network topology that can be used with "
-"pgRouting out-of-the-box. Often network data is stored in Shape file "
-"format (``.shp``) and we can use PostGIS' ``shp2pgsql`` converter to "
-"import the data into a PostgreSQL database."
+":doc:`osm2pgrouting <../appendix/appendix-3>` is a convenient tool, and its "
+"focus to work on OpenStreetMap data. There are several cases where :doc:"
+"`osm2pgrouting <../appendix/appendix-3>` can't be used. Some network data "
+"already comes with a network topology that can be used with pgRouting out-of-"
+"the-box. Often network data is stored in Shape file format (``.shp``) and we "
+"can use PostGIS' ``shp2pgsql`` converter to import the data into a "
+"PostgreSQL database."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:24
@@ -42,8 +42,8 @@ msgstr ""
 #: ../../build/docs/advanced/chapter-12.rst:26
 msgid ""
 "In this chapter you will learn how to create a basic `Routing Network "
-"Topology` from a network data that does not have a routing Topology "
-"create the minimum attributes needed the `Routing Network Topology`."
+"Topology` from a network data that does not have a routing Topology create "
+"the minimum attributes needed the `Routing Network Topology`."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:31
@@ -104,9 +104,9 @@ msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:66
 msgid ""
-"This allows to display the road network as a PostGIS layer in GIS "
-"software, for example in QGIS. Though it is not sufficient for routing, "
-"because it doesn't contain network topology information."
+"This allows to display the road network as a PostGIS layer in GIS software, "
+"for example in QGIS. Though it is not sufficient for routing, because it "
+"doesn't contain network topology information."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:70
@@ -119,16 +119,16 @@ msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:81
 msgid ""
-"Having your data imported into a PostgreSQL database might require one "
-"more step for pgRouting."
+"Having your data imported into a PostgreSQL database might require one more "
+"step for pgRouting."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:84
 msgid ""
 "Make sure that your data provides a correct `Routing Network Topology`, "
-"which consists of information about source and target identifiers for "
-"each road link. The results above, show that the network topology does "
-"not have any source and target information."
+"which consists of information about source and target identifiers for each "
+"road link. The results above, show that the network topology does not have "
+"any source and target information."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:89
@@ -141,8 +141,8 @@ msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:94
 msgid ""
-"pgRouting provides a general way for creating the `Routing Network "
-"Topology` with the ``pgr_createTopology`` function."
+"pgRouting provides a general way for creating the `Routing Network Topology` "
+"with the ``pgr_createTopology`` function."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:97
@@ -160,7 +160,7 @@ msgid ""
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:102
-msgid "Creates a vertices table related to it."
+msgid "Creates a ways_vertices_pgr table related to it."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:103
@@ -169,8 +169,8 @@ msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:109
 msgid ""
-"For additional information see `pgr_createTopology "
-"<https://docs.pgrouting.org/latest/en/pgr_createTopology.html>`_."
+"For additional information see `pgr_createTopology <https://docs.pgrouting."
+"org/latest/en/pgr_createTopology.html>`_."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:112
@@ -180,7 +180,8 @@ msgid ""
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:115
-msgid "Depending on the network size this process may take from minutes to hours."
+msgid ""
+"Depending on the network size this process may take from minutes to hours."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:116
@@ -195,9 +196,9 @@ msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:120
 msgid ""
-"The dimension of the tolerance parameter depends on your data projection."
-" Usually it's either \"degrees\" or \"meters\". In our example the "
-"geometry data projection to determine the tolerance:"
+"The dimension of the tolerance parameter depends on your data projection. "
+"Usually it's either \"degrees\" or \"meters\". In our example the geometry "
+"data projection to determine the tolerance:"
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:132
@@ -213,7 +214,8 @@ msgid "To verify that there is a basic `Routing Network Topology`:"
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:153
-msgid "Also a new table containing the vertices information was created:"
+msgid ""
+"Also a new table containing the ways_vertices_pgr information was created:"
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:159
@@ -238,9 +240,9 @@ msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:165
 msgid ""
-"Now we are ready for our first routing query with `pgr_dijkstra "
-"<https://docs.pgrouting.org/latest/en/pgr_dijkstra.html>`__ or any other "
-"pgRouting query."
+"Now we are ready for our first routing query with `pgr_dijkstra <https://"
+"docs.pgrouting.org/latest/en/pgr_dijkstra.html>`__ or any other pgRouting "
+"query."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:172
@@ -249,8 +251,8 @@ msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:174
 msgid ""
-"Analyzing the topology with `pgr_analyzeGraph "
-"<https://docs.pgrouting.org/latest/en/pgr_analyzeGraph.html>`_:"
+"Analyzing the topology with `pgr_analyzeGraph <https://docs.pgrouting.org/"
+"latest/en/pgr_analyzeGraph.html>`_:"
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:181
@@ -285,8 +287,7 @@ msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:192
 msgid ""
-"Some `topology manipulation <https://docs.pgrouting.org/latest/en"
-"/topology-functions.html>`_ functions help to detect and fix some of the "
-"topological errors in the data."
+"Some `topology manipulation <https://docs.pgrouting.org/latest/en/topology-"
+"functions.html>`_ functions help to detect and fix some of the topological "
+"errors in the data."
 msgstr ""
-

--- a/locale/en/LC_MESSAGES/basic/graphs.po
+++ b/locale/en/LC_MESSAGES/basic/graphs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-03 17:35+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: ../../build/docs/basic/graphs.rst:12
 msgid "Graphs"
@@ -196,7 +196,7 @@ msgid ""
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:144
-msgid "Exercise 1: Create a vertices table"
+msgid "Exercise 1: Create a ways_vertices_pgr table"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:147 ../../build/docs/basic/graphs.rst:196
@@ -207,7 +207,8 @@ msgid "Problem"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:148
-msgid "Create the vertices table corresponding to the edges in ``ways``."
+msgid ""
+"Create the ways_vertices_pgr table corresponding to the edges in ``ways``."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:151 ../../build/docs/basic/graphs.rst:200
@@ -238,19 +239,19 @@ msgid ""
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:170
-msgid "Reviewing the description of the vertices table"
+msgid "Reviewing the description of the ways_vertices_pgr table"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:180
-msgid "Inspecting the information on the vertices table"
+msgid "Inspecting the information on the ways_vertices_pgr table"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:193
-msgid "Exercise 2: Fill up other columns in the vertices table"
+msgid "Exercise 2: Fill up other columns in the ways_vertices_pgr table"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:197
-msgid "Fill up geometry information on the vertices table."
+msgid "Fill up geometry information on the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:201
@@ -264,7 +265,7 @@ msgstr ""
 #: ../../build/docs/basic/graphs.rst:213
 msgid ""
 "The update based on the ``source`` column from ``ways`` table and the ``id`` "
-"column of the vertices table."
+"column of the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:215
@@ -284,7 +285,8 @@ msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:230
 msgid ""
-"Not expecting to be done due to the fact that some vertices are dead ends."
+"Not expecting to be done due to the fact that some ways_vertices_pgr are "
+"dead ends."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:242
@@ -294,7 +296,7 @@ msgstr ""
 #: ../../build/docs/basic/graphs.rst:243
 msgid ""
 "The update based on the ``target`` column from ``ways`` table and the ``id`` "
-"column of the vertices table."
+"column of the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:245
@@ -340,7 +342,7 @@ msgid ""
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:309
-msgid "Exercise 3: Set components on edges and vertices tables"
+msgid "Exercise 3: Set components on edges and ways_vertices_pgr tables"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:313
@@ -352,11 +354,14 @@ msgid "Create additional columns on the edges tables."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:329
-msgid "Use the ``pgr_connectedComponents`` to fill up the vertices table."
+msgid ""
+"Use the ``pgr_connectedComponents`` to fill up the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:330
-msgid "Use the results to store the component numbers on the vertices table."
+msgid ""
+"Use the results to store the component numbers on the ways_vertices_pgr "
+"table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:343
@@ -372,7 +377,7 @@ msgid "Answer the following questions:"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:361
-msgid "How many components are in the vertices table?"
+msgid "How many components are in the ways_vertices_pgr table?"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:362
@@ -388,7 +393,7 @@ msgid "Get the component with the maximum number of edges."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:369
-msgid "1. How many components are in the vertices table?"
+msgid "1. How many components are in the ways_vertices_pgr table?"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:370 ../../build/docs/basic/graphs.rst:383

--- a/locale/en/LC_MESSAGES/basic/pedestrian.po
+++ b/locale/en/LC_MESSAGES/basic/pedestrian.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-28 19:15+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: ../../build/docs/basic/pedestrian.rst:11
 msgid "Pedestrian Routing"
@@ -336,22 +336,6 @@ msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:1
 msgid "Inspecting the results, looking for totals (edge = -1):"
-msgstr ""
-
-#: ../../build/docs/scripts/basic/pedestrian/note_1.txt:3
-msgid "From 10832 to vertex 11046 takes 9.82 minutes (seq = 134)"
-msgstr ""
-
-#: ../../build/docs/scripts/basic/pedestrian/note_1.txt:5
-msgid "From 10832 to vertex 14824 takes 10.85 minutes (seq = 185)"
-msgstr ""
-
-#: ../../build/docs/scripts/basic/pedestrian/note_1.txt:7
-msgid "From 593 to vertex 11046 takes 9.07 minutes (seq = 50)"
-msgstr ""
-
-#: ../../build/docs/scripts/basic/pedestrian/note_1.txt:9
-msgid "From 593 to vertex 14824 takes 9.04 minutes (seq = 85)"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:248

--- a/locale/en/LC_MESSAGES/un_sdg/sdg11-cities.po
+++ b/locale/en/LC_MESSAGES/un_sdg/sdg11-cities.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-10 17:09+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:11
 msgid "Sustainable Cities and Communities"
@@ -28,13 +28,13 @@ msgstr ""
 msgid ""
 "`Sustainable Cities and Communities` is the 11th Sustainable Development "
 "Goal which aspires to make cities `inclusive, safe, resilient` and "
-"`sustainable`.The world is becoming increasingly urbanized. Since 2007, "
-"more than half the world’s population has been living in cities. This "
-"makes it very important for the cities to remain alert when there is a "
-"chance of disaster like floods. Local administration should know if their"
-" city is going to get affected by the rains which happen in their "
-"proximity so that they can raise an alert amongst the citizens. This "
-"exercise will solve one of such problems."
+"`sustainable`.The world is becoming increasingly urbanized. Since 2007, more "
+"than half the world’s population has been living in cities. This makes it "
+"very important for the cities to remain alert when there is a chance of "
+"disaster like floods. Local administration should know if their city is "
+"going to get affected by the rains which happen in their proximity so that "
+"they can raise an alert amongst the citizens. This exercise will solve one "
+"of such problems."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:22
@@ -67,8 +67,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:43
 msgid ""
-"If it rains in vicinity of a river connecting the city, the city will get"
-" affected by the rains."
+"If it rains in vicinity of a river connecting the city, the city will get "
+"affected by the rains."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:46
@@ -102,13 +102,13 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:61
 msgid ""
-"For this exercise, Munshigang city from Bangladesh is chosen. This city "
-"has multiple rivers in its proximity which makes it an apt location to "
-"demonstrate this exercise. The exercise will try to find the areas, where"
-" if it rains the city will be affected. To define the location of this "
-"city and use it in for further steps, create a table to store the name "
-"along with latitude and longitude values of City's location. This stores "
-"the city as a point."
+"For this exercise, Munshigang city from Bangladesh is chosen. This city has "
+"multiple rivers in its proximity which makes it an apt location to "
+"demonstrate this exercise. The exercise will try to find the areas, where if "
+"it rains the city will be affected. To define the location of this city and "
+"use it in for further steps, create a table to store the name along with "
+"latitude and longitude values of City's location. This stores the city as a "
+"point."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:69
@@ -134,9 +134,9 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg11-cities.rst:114
 msgid ""
 "Latitude and longitude values are converted into ``geometry`` form using "
-"``ST_Point`` which returns a point with the given X and Y coordinate "
-"values. ``ST_SetSRID`` is used to set the SRID (Spatial Reference "
-"Identifier) on the point geometry to ``4326``."
+"``ST_Point`` which returns a point with the given X and Y coordinate values. "
+"``ST_SetSRID`` is used to set the SRID (Spatial Reference Identifier) on the "
+"point geometry to ``4326``."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:120
@@ -149,8 +149,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:124
 msgid ""
-"This section will cover the status of the database in order to get the "
-"same results when processing the queries."
+"This section will cover the status of the database in order to get the same "
+"results when processing the queries."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:128
@@ -160,8 +160,8 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg11-cities.rst:130
 msgid ""
 "First step in pre processing is to set the search path for ``Waterways`` "
-"data. Search path is a list of schemas that helps the system determine "
-"how a particular table is to be imported."
+"data. Search path is a list of schemas that helps the system determine how a "
+"particular table is to be imported."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:145
@@ -186,10 +186,10 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:172
 msgid ""
-"The importance of counting the information on this workshop is to make "
-"sure that the same data is used and consequently the results are same. "
-"Also, some of the rows can be seen to understand the structure of the "
-"table and how the data is stored in it."
+"The importance of counting the information on this workshop is to make sure "
+"that the same data is used and consequently the results are same. Also, some "
+"of the rows can be seen to understand the structure of the table and how the "
+"data is stored in it."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:187
@@ -198,11 +198,11 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:189
 msgid ""
-"This section will work the graph that is going to be used for processing."
-" While building the graph, the data has to be inspected to determine if "
-"there is any invalid data. This is a very important step to make sure "
-"that the data is of required quality. pgRouting can also be used to do "
-"some Data Adjustments."
+"This section will work the graph that is going to be used for processing. "
+"While building the graph, the data has to be inspected to determine if there "
+"is any invalid data. This is a very important step to make sure that the "
+"data is of required quality. pgRouting can also be used to do some Data "
+"Adjustments."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:195
@@ -215,9 +215,9 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:201
 msgid ""
-"This exercise focusses only the areas in the mainland, where if it rains "
-"the city is affected. Hence, the rivers which are there in the swamp area"
-" wich is in a lower altitude of the city, are to be removed from the "
+"This exercise focusses only the areas in the mainland, where if it rains the "
+"city is affected. Hence, the rivers which are there in the swamp area wich "
+"is in a lower altitude of the city, are to be removed from the "
 "``waterways_ways`` table."
 msgstr ""
 
@@ -226,7 +226,8 @@ msgid "Remove swamp rivers"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:216
-msgid "When working for many cities, a better approach might be to create views."
+msgid ""
+"When working for many cities, a better approach might be to create views."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:220
@@ -243,32 +244,31 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:235
 msgid ""
-"As the rivers in the data are not having single edge, i.e, multiple edges"
-" make up a river, it is important to find out the connected edges and "
-"store the information in the ``waterways_ways`` table. This will help us "
-"to identify which edges belong to a river. First, the connected "
-"components are found and then stored in a new column named ``component``."
+"As the rivers in the data are not having single edge, i.e, multiple edges "
+"make up a river, it is important to find out the connected edges and store "
+"the information in the ``waterways_ways`` table. This will help us to "
+"identify which edges belong to a river. First, the connected components are "
+"found and then stored in a new column named ``component``."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:241
 msgid ""
-"The pgRouting function ``pgr_connectedComponents`` is used to complete "
-"this task and its explaind with more detail in "
-":doc:`../basic/graphs`."
+"The pgRouting function ``pgr_connectedComponents`` is used to complete this "
+"task and its explaind with more detail in :doc:`../basic/graphs`."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:244
 msgid ""
-"A sub-query is created to find out all the connected components. After "
-"that, the ``component`` column is updated using the results obtained from"
-" the sub-query. This helps in storing the component id in the "
+"A sub-query is created to find out all the connected components. After that, "
+"the ``component`` column is updated using the results obtained from the sub-"
+"query. This helps in storing the component id in the "
 "``waterways_ways_vertices_pgr`` table. Next query uses this output and "
 "stores the component id in the waterways_ways (edges) table. Follow the "
 "steps given below to complete this task."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:251
-msgid "Create a vertices table."
+msgid "Create a ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:262
@@ -276,11 +276,11 @@ msgid "Fill up the ``x``, ``y`` and ``geom`` columns."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:273
-msgid "Add a ``component`` column on the edges and vertices tables."
+msgid "Add a ``component`` column on the edges and ways_vertices_pgr tables."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:284
-msgid "Fill up the ``component`` column on the vertices table."
+msgid "Fill up the ``component`` column on the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:295
@@ -304,15 +304,15 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg11-cities.rst:321
 msgid ""
 "Next step is to find the components of waterways which lie in the buffer "
-"zone of the city. These are the waterways which will affect the city when"
-" it rains around them. This is done using ``ST_Intersects``. Note that "
+"zone of the city. These are the waterways which will affect the city when it "
+"rains around them. This is done using ``ST_Intersects``. Note that "
 "``get_city_buffer`` function is used in the query below."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:336
 msgid ""
-"Output shows the distinct component numbers which lie in the buffer zone "
-"of the city. That is, the rivers that lie within the city."
+"Output shows the distinct component numbers which lie in the buffer zone of "
+"the city. That is, the rivers that lie within the city."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:341
@@ -321,9 +321,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:343
 msgid ""
-"In this excercise the area , where if it rains, the city would be "
-"affected, is calculated. This area is called ``rain zone`` in the "
-"excercise"
+"In this excercise the area , where if it rains, the city would be affected, "
+"is calculated. This area is called ``rain zone`` in the excercise"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:346
@@ -340,8 +339,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:352
 msgid ""
-"Find the buffer for every edge that intersects the city buffer area using"
-" ``ST_Buffer``"
+"Find the buffer for every edge that intersects the city buffer area using "
+"``ST_Buffer``"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:353
@@ -368,11 +367,10 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:381
 msgid ""
-"Multiple polygons that are obtained can also be merged using "
-"``ST_Union``. This will give a single polygon as the output."
+"Multiple polygons that are obtained can also be merged using ``ST_Union``. "
+"This will give a single polygon as the output."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:388
 msgid "When it rains in the vicinity, the city will get affected by the rain."
 msgstr ""
-

--- a/locale/en/LC_MESSAGES/un_sdg/sdg3-health.po
+++ b/locale/en/LC_MESSAGES/un_sdg/sdg3-health.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:44+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:11
 msgid "Good Health and Well Being"
@@ -26,20 +26,19 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:13
 msgid ""
-"`Good Health and Well Being` is the 3rd Sustainable Development Goal "
-"which aspires to ensure health and well-being for all, including a bold "
-"commitment to end the epidemics like AIDS, tuberculosis, malaria and "
-"other communicable diseases by 2030. It also aims to achieve universal "
-"health coverage, and provide access to safe and effective medicines and "
-"vaccines for all. Supporting research and development for vaccines is an "
-"essential part of this process as well as expanding access to affordable "
-"medicines. Hospitals are a very important part of a well functioning "
-"health infrastructure. An appropriate planning is required for optimal "
-"distribution of the population of an area to its hospitals. Hence, it is "
-"very important to estimate the number of dependant people living near the"
-" hospital for better planning which would ultimately help in achieving "
-"universal coverage of health services. This chapter will focus on solving"
-" one such problem."
+"`Good Health and Well Being` is the 3rd Sustainable Development Goal which "
+"aspires to ensure health and well-being for all, including a bold commitment "
+"to end the epidemics like AIDS, tuberculosis, malaria and other communicable "
+"diseases by 2030. It also aims to achieve universal health coverage, and "
+"provide access to safe and effective medicines and vaccines for all. "
+"Supporting research and development for vaccines is an essential part of "
+"this process as well as expanding access to affordable medicines. Hospitals "
+"are a very important part of a well functioning health infrastructure. An "
+"appropriate planning is required for optimal distribution of the population "
+"of an area to its hospitals. Hence, it is very important to estimate the "
+"number of dependant people living near the hospital for better planning "
+"which would ultimately help in achieving universal coverage of health "
+"services. This chapter will focus on solving one such problem."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:26
@@ -128,8 +127,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:68
 msgid ""
-"By setting the ``search_path`` to appropriate values, prepending the "
-"schema name to tables can be avoided."
+"By setting the ``search_path`` to appropriate values, prepending the schema "
+"name to tables can be avoided."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:72
@@ -158,8 +157,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:102
 msgid ""
-"This is the current search path. Tables in other schemas cannot be "
-"accessed with this path."
+"This is the current search path. Tables in other schemas cannot be accessed "
+"with this path."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:106
@@ -168,9 +167,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:108
 msgid ""
-"In this case, the search path needs to include ``roads`` and "
-"``buildings`` schemas. The following query is used to adjust the search "
-"path."
+"In this case, the search path needs to include ``roads`` and ``buildings`` "
+"schemas. The following query is used to adjust the search path."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:119
@@ -198,8 +196,8 @@ msgid ""
 "This section will work the graph and data that is going to be used for "
 "processing. While building the graph, the data has to be inspected to "
 "determine if there is any invalid data. This is a very important step to "
-"make sure that the data is of required quality. pgRouting can also be "
-"used to do some Data Adjustments."
+"make sure that the data is of required quality. pgRouting can also be used "
+"to do some Data Adjustments."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:156
@@ -208,10 +206,10 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:158
 msgid ""
-"The importance of counting the information on this workshop is to make "
-"sure that the same data is used and consequently the results are same. "
-"Also, some of the rows can be seen to understand the structure of the "
-"table and how the data is stored in it."
+"The importance of counting the information on this workshop is to make sure "
+"that the same data is used and consequently the results are same. Also, some "
+"of the rows can be seen to understand the structure of the table and how the "
+"data is stored in it."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:181
@@ -224,10 +222,9 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:190
 msgid ""
-"The table ``buildings_ways`` contains the buildings in ``LINGSTING`` "
-"type. They have to be converted into polygons to get the area, as the "
-"area is going to be used to get an estimate of the population living in "
-"the building."
+"The table ``buildings_ways`` contains the buildings in ``LINGSTING`` type. "
+"They have to be converted into polygons to get the area, as the area is "
+"going to be used to get an estimate of the population living in the building."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:195
@@ -247,8 +244,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:214
 msgid ""
-"Add a spatial column named ``poly_geom`` to the table ``buildings_ways`` "
-"to store the Polygon Geometry"
+"Add a spatial column named ``poly_geom`` to the table ``buildings_ways`` to "
+"store the Polygon Geometry"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:226
@@ -261,11 +258,10 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:239
 msgid ""
-"``ST_NumPoints`` is used to find the number of points on a geometry. "
-"Also, polygons with less than 3 points/vertices are not considered valid "
-"polygons in PostgreSQL. Hence, the buildings having less than 3 vertices "
-"need to be cleaned up. Follow the steps given below to complete this "
-"task."
+"``ST_NumPoints`` is used to find the number of points on a geometry. Also, "
+"polygons with less than 3 points/vertices are not considered valid polygons "
+"in PostgreSQL. Hence, the buildings having less than 3 vertices need to be "
+"cleaned up. Follow the steps given below to complete this task."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:254
@@ -275,8 +271,7 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg3-health.rst:256
 msgid ""
 "``ST_MakePolygons`` is used to make the polygons. This step stores the "
-"geometry of polygons in the ``poly_geom`` column which was created "
-"earlier."
+"geometry of polygons in the ``poly_geom`` column which was created earlier."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:270
@@ -299,8 +294,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:284
 msgid ""
-"``ST_Area`` is used to calculate area of polygons. Area is stored in the "
-"new column"
+"``ST_Area`` is used to calculate area of polygons. Area is stored in the new "
+"column"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:297
@@ -309,9 +304,9 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:299
 msgid ""
-"Due to the lack of census data, this exercise will fill up and estimate "
-"of the population living on the buildings, based on the area of the "
-"building and the kind of use the building gets."
+"Due to the lack of census data, this exercise will fill up and estimate of "
+"the population living on the buildings, based on the area of the building "
+"and the kind of use the building gets."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:303
@@ -416,21 +411,21 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:359
 msgid ""
-"This class-specific factor is multiplied with the area of each building "
-"to get the population. Follow the steps given below to complete this "
-"task."
+"This class-specific factor is multiplied with the area of each building to "
+"get the population. Follow the steps given below to complete this task."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:362
-msgid "Create a function to find population using class-specific factor and area."
+msgid ""
+"Create a function to find population using class-specific factor and area."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:374
 msgid ""
-"All these are estimations based on this particular area. More complicated"
-" functions can be done that consider height of the apartments but the "
-"design of a function is going to depend on the availability of the data. "
-"For example, using census data can achieve more accurate estimation."
+"All these are estimations based on this particular area. More complicated "
+"functions can be done that consider height of the apartments but the design "
+"of a function is going to depend on the availability of the data. For "
+"example, using census data can achieve more accurate estimation."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:379
@@ -439,8 +434,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:390
 msgid ""
-"3. Use the ``population`` function to store the population in the new "
-"column created in the ``building_ways``."
+"3. Use the ``population`` function to store the population in the new column "
+"created in the ``building_ways``."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:403
@@ -451,18 +446,17 @@ msgstr ""
 msgid ""
 "pgRouting algorithms are only useful when the road network belongs to a "
 "single graph (or all the roads are connected to each other). Hence, the "
-"disconnected roads have to be removed from their network to get "
-"appropriate results. This image gives an example of the disconnected "
-"edges."
+"disconnected roads have to be removed from their network to get appropriate "
+"results. This image gives an example of the disconnected edges."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:413
 msgid ""
-"For example, in the above figure roads with label ``119`` are "
-"disconnected from the network. Hence they will have same connected "
-"component number. But the count of this number will be less count of "
-"fully connected network. All the edges with the component number with "
-"count less than maximum count will be removed"
+"For example, in the above figure roads with label ``119`` are disconnected "
+"from the network. Hence they will have same connected component number. But "
+"the count of this number will be less count of fully connected network. All "
+"the edges with the component number with count less than maximum count will "
+"be removed"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:418
@@ -477,8 +471,7 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg3-health.rst:423
 msgid ""
 "To remove the disconnected components on the road network, the following "
-"pgRouting functions, discussed on :doc:`../basic/graphs`, will be "
-"used:"
+"pgRouting functions, discussed on :doc:`../basic/graphs`, will be used:"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:426
@@ -490,7 +483,7 @@ msgid "``pgr_connectedComponents``"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:430
-msgid "Create a vertices table."
+msgid "Create a ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:441
@@ -498,11 +491,11 @@ msgid "Fill up the ``x``, ``y`` and ``geom`` columns."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:452
-msgid "Add a ``component`` column on the edges and vertices tables."
+msgid "Add a ``component`` column on the edges and ways_vertices_pgr tables."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:463
-msgid "Fill up the ``component`` column on the vertices table."
+msgid "Fill up the ``component`` column on the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:474
@@ -518,7 +511,7 @@ msgid "Delete edges not belonging to the most connected component."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:507
-msgid "Delete vertices not belonging to the most connected component."
+msgid "Delete ways_vertices_pgr not belonging to the most connected component."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:518
@@ -527,11 +520,11 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:519
 msgid ""
-"After pre-processing the data, next step is to find the area served by "
-"the hospital. This area can be computed from the entrance of the hospital"
-" or from any point on road near the hospital. In this exercise it is "
-"computed from closest road vertex. ``pgr_drivingDistance`` will be used "
-"to find the roads served. The steps to be followed are:"
+"After pre-processing the data, next step is to find the area served by the "
+"hospital. This area can be computed from the entrance of the hospital or "
+"from any point on road near the hospital. In this exercise it is computed "
+"from closest road vertex. ``pgr_drivingDistance`` will be used to find the "
+"roads served. The steps to be followed are:"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:525
@@ -555,8 +548,8 @@ msgid ""
 "For the next step ``pgr_drivingDistance`` will be used. This returns the "
 "driving distance from a start node. It uses the Dijkstra algorithm to "
 "extract all the nodes that have costs less than or equal to the value "
-"distance. The edges that are extracted conform to the corresponding "
-"spanning tree."
+"distance. The edges that are extracted conform to the corresponding spanning "
+"tree."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:537
@@ -565,9 +558,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:544
 msgid ""
-"`pgr_drivingDistance Documentation "
-"<https://docs.pgrouting.org/3.1/en/pgr_drivingDistance>`__ can be found "
-"at this link for more information."
+"`pgr_drivingDistance Documentation <https://docs.pgrouting.org/3.1/en/"
+"pgr_drivingDistance>`__ can be found at this link for more information."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:548
@@ -576,10 +568,10 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:549
 msgid ""
-"There are multiple road vertices near the hospital. Create a function to "
-"find the geographically closest road vertex. ``closest_vertex`` function "
-"takes geometry of other table as input and gives the gid of the closest "
-"vertex as output by comparing ``geom`` of both the tables."
+"There are multiple road ways_vertices_pgr near the hospital. Create a "
+"function to find the geographically closest road vertex. ``closest_vertex`` "
+"function takes geometry of other table as input and gives the gid of the "
+"closest vertex as output by comparing ``geom`` of both the tables."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:558
@@ -600,8 +592,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:587
 msgid ""
-"Find the roads within 10 minutes walking distance from the hospitals. Use"
-" ``1 m/s`` as walking speed."
+"Find the roads within 10 minutes walking distance from the hospitals. Use "
+"``1 m/s`` as walking speed."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:591
@@ -610,9 +602,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:592
 msgid ""
-"In this exercise, the roads served are calculated based on a walking time"
-" of ``1 m/s``, by using ``pgrdrivingDistance`` function from pgRouting "
-"extension."
+"In this exercise, the roads served are calculated based on a walking time of "
+"``1 m/s``, by using ``pgrdrivingDistance`` function from pgRouting extension."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:595
@@ -641,8 +632,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:615
 msgid ""
-"As ``time`` = ``distance/speed``, ``length_m`` / ``1 m/s`` / ``60`` gives"
-" the time in minutes."
+"As ``time`` = ``distance/speed``, ``length_m`` / ``1 m/s`` / ``60`` gives "
+"the time in minutes."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:618
@@ -657,17 +648,17 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:632
 msgid ""
-"Following figure shows the visualised output of the above query. The "
-"lines highlighted by red colour show the area from where the hospital can"
-" be reached within 10 minutes of walking at the speed of ``1 m/s``."
+"Following figure shows the visualised output of the above query. The lines "
+"highlighted by red colour show the area from where the hospital can be "
+"reached within 10 minutes of walking at the speed of ``1 m/s``."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:636
 msgid ""
-"It is noticable from the output figure that some of the roads which are "
-"near to the hospital are not highlighted. For example, to roads in the "
-"north of the hospital. This is because the only one edge per road vertex "
-"was selected by the query."
+"It is noticable from the output figure that some of the roads which are near "
+"to the hospital are not highlighted. For example, to roads in the north of "
+"the hospital. This is because the only one edge per road vertex was selected "
+"by the query."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:646
@@ -676,19 +667,19 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:648
 msgid ""
-"The edges which are near to to hospital should also be selected in the "
-"roads served as the hospital also serves those buildings. The following "
-"query takes the query from previous section as a ``subquery`` and selects"
-" all the edges from ``roads_ways`` that have the same ``source`` and "
-"``target`` to that of ``subquery`` (Line 14)."
+"The edges which are near to to hospital should also be selected in the roads "
+"served as the hospital also serves those buildings. The following query "
+"takes the query from previous section as a ``subquery`` and selects all the "
+"edges from ``roads_ways`` that have the same ``source`` and ``target`` to "
+"that of ``subquery`` (Line 14)."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:663
 msgid ""
 "Following figure shows the visualised output of the above query. Lines "
 "highlighted in ``yellow`` show the `generalised the roads served`. This "
-"gives a better estimate of the areas from where the hospital can be "
-"reached by a particular speed."
+"gives a better estimate of the areas from where the hospital can be reached "
+"by a particular speed."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:672
@@ -697,11 +688,11 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:674
 msgid ""
-"Now the next step is to estimate the dependant population. Official "
-"source of population is Census conducted by the government. But for this "
-"exercise, population will be estimated from the ``area`` as well as the "
-"``category`` of the building. This area will be stored in the nearest "
-"roads. Following steps explain this process in detail."
+"Now the next step is to estimate the dependant population. Official source "
+"of population is Census conducted by the government. But for this exercise, "
+"population will be estimated from the ``area`` as well as the ``category`` "
+"of the building. This area will be stored in the nearest roads. Following "
+"steps explain this process in detail."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:682
@@ -711,8 +702,7 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg3-health.rst:684
 msgid ""
 "To store the population of buildings in the roads, nearest road to a "
-"building is to be found. Follow the steps given below to complete this "
-"task."
+"building is to be found. Follow the steps given below to complete this task."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:687
@@ -725,8 +715,7 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:710
 msgid ""
-"Store the edge id of the closest edge in the new column of "
-"``buildings_ways``"
+"Store the edge id of the closest edge in the new column of ``buildings_ways``"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:723
@@ -736,9 +725,9 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg3-health.rst:724
 msgid ""
 "After finding the nearest road, the sum of population of all the nearest "
-"buildings is stored in the population column of the roads table. "
-"Following image shows the visualised output where the blue colour labels "
-"shows the population stored in roads."
+"buildings is stored in the population column of the roads table. Following "
+"image shows the visualised output where the blue colour labels shows the "
+"population stored in roads."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:735
@@ -759,7 +748,6 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:773
 msgid ""
-"Final step is to find the total population served by the hospital based "
-"on travel time."
+"Final step is to find the total population served by the hospital based on "
+"travel time."
 msgstr ""
-

--- a/locale/en/LC_MESSAGES/un_sdg/sdg7-energy.po
+++ b/locale/en/LC_MESSAGES/un_sdg/sdg7-energy.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:44+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.18.0\n"
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:11
 msgid "Affordable and Clean Energy"
@@ -26,16 +26,15 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:13
 msgid ""
-"`Affordable and Clean Energy` is the 7th Sustainable Development Goal 11."
-" It aspires to ensure access to `affordable, reliable, sustainable` and "
-"`modern` energy for all. Today renewable energy is making impressive "
-"gains in the electricity sector. As more and more new settlements are "
-"built, there would be new electricity distribution network developed. "
-"Electricity Distribution is very expensive infrastructure. Finding the "
-"optimal path for laying this infrastructure is very crucial to maintain "
-"the affordability of electricity for everyone. This exercise focusses on "
-"finding this optimal path/network for laying the electricity distribution"
-" equipment."
+"`Affordable and Clean Energy` is the 7th Sustainable Development Goal 11. It "
+"aspires to ensure access to `affordable, reliable, sustainable` and `modern` "
+"energy for all. Today renewable energy is making impressive gains in the "
+"electricity sector. As more and more new settlements are built, there would "
+"be new electricity distribution network developed. Electricity Distribution "
+"is very expensive infrastructure. Finding the optimal path for laying this "
+"infrastructure is very crucial to maintain the affordability of electricity "
+"for everyone. This exercise focusses on finding this optimal path/network "
+"for laying the electricity distribution equipment."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:22
@@ -70,11 +69,10 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:44
 msgid ""
-"Electricity lines may not be there on every road of the city. In a "
-"complex road network of a city, the network can be optimised for less "
-"length such that Electricity lines reach every locality of the city. Less"
-" length leads to enhanced cost-effectiveness resulting in affordable "
-"electricity."
+"Electricity lines may not be there on every road of the city. In a complex "
+"road network of a city, the network can be optimised for less length such "
+"that Electricity lines reach every locality of the city. Less length leads "
+"to enhanced cost-effectiveness resulting in affordable electricity."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:49
@@ -100,11 +98,11 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg7-energy.rst:58
 msgid ""
 "First step is to pre-process the data obtained from :doc:`data`. This "
-"section will work the graph that is going to be used for processing. "
-"While building the graph, the data has to be inspected to determine if "
-"there is any invalid data. This is a very important step to make sure "
-"that the data is of required quality. pgRouting can also be used to do "
-"some Data Adjustments. This will be discussed in further sections."
+"section will work the graph that is going to be used for processing. While "
+"building the graph, the data has to be inspected to determine if there is "
+"any invalid data. This is a very important step to make sure that the data "
+"is of required quality. pgRouting can also be used to do some Data "
+"Adjustments. This will be discussed in further sections."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:66
@@ -113,9 +111,9 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:67
 msgid ""
-"First step in pre processing is to set the search path for ``Roads`` "
-"data. Search path is a list of schemas helps the system determine how a "
-"particular table is to be imported."
+"First step in pre processing is to set the search path for ``Roads`` data. "
+"Search path is a list of schemas helps the system determine how a particular "
+"table is to be imported."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:72
@@ -139,8 +137,7 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg7-energy.rst:99
 msgid ""
 "To remove the disconnected components on the road network, the following "
-"pgRouting functions, discussed on :doc:`../basic/graphs`, will be "
-"used:"
+"pgRouting functions, discussed on :doc:`../basic/graphs`, will be used:"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:102
@@ -152,7 +149,7 @@ msgid "``pgr_connectedComponents``"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:106
-msgid "Create a vertices table."
+msgid "Create a ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:117
@@ -160,11 +157,11 @@ msgid "Fill up the ``x``, ``y`` and ``geom`` columns."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:128
-msgid "Add a ``component`` column on the edges and vertices tables."
+msgid "Add a ``component`` column on the edges and ways_vertices_pgr tables."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:139
-msgid "Fill up the ``component`` column on the vertices table."
+msgid "Fill up the ``component`` column on the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:150
@@ -180,7 +177,7 @@ msgid "Delete edges not belonging to the most connected component."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:183
-msgid "Delete vertices not belonging to the most connected component."
+msgid "Delete ways_vertices_pgr not belonging to the most connected component."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:195
@@ -189,11 +186,11 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:197
 msgid ""
-"For the next step ``pgr_kruskalDFS`` will be used. Kruskal algorithm is "
-"used for getting the Minimum Spanning Tree with Depth First Search "
-"ordering. A minimum spanning tree (MST) is a subset of edges of a "
-"connected undirected graph that connects all the vertices together, "
-"without any cycles such that sum of edge weights is as small as possible."
+"For the next step ``pgr_kruskalDFS`` will be used. Kruskal algorithm is used "
+"for getting the Minimum Spanning Tree with Depth First Search ordering. A "
+"minimum spanning tree (MST) is a subset of edges of a connected undirected "
+"graph that connects all the vertices together, without any cycles such that "
+"sum of edge weights is as small as possible."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:204
@@ -202,9 +199,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:212
 msgid ""
-"`pgr_kruskalDFS Documentation "
-"<https://docs.pgrouting.org/3.1/en/pgr_kruskalDFS.html>`__ can be found "
-"at this link for more information."
+"`pgr_kruskalDFS Documentation <https://docs.pgrouting.org/3.1/en/"
+"pgr_kruskalDFS.html>`__ can be found at this link for more information."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:216
@@ -214,9 +210,8 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg7-energy.rst:218
 msgid ""
 "The road network has a minimum spanning forest which is a union of the "
-"minimum spanning trees for its connected components. This minimum "
-"spanning forest is the optimal network of electricity distribution "
-"components."
+"minimum spanning trees for its connected components. This minimum spanning "
+"forest is the optimal network of electricity distribution components."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:222
@@ -235,9 +230,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:248
 msgid ""
-"Total lengths of the network and the minimum spanning tree can be "
-"compared to see the difference between both. To do the same, follow the "
-"steps below:"
+"Total lengths of the network and the minimum spanning tree can be compared "
+"to see the difference between both. To do the same, follow the steps below:"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:252
@@ -246,8 +240,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:254
 msgid ""
-"Compute the total length of the minimum spanning tree which is an "
-"estimate of the total length of material required."
+"Compute the total length of the minimum spanning tree which is an estimate "
+"of the total length of material required."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:268
@@ -266,8 +260,8 @@ msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:286
 msgid ""
-"Length of minimum spanning tree is about half of the length of total road"
-" network."
+"Length of minimum spanning tree is about half of the length of total road "
+"network."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:289
@@ -281,4 +275,3 @@ msgstr ""
 #: ../../build/docs/un_sdg/sdg7-energy.rst:292
 msgid "Find the optimal number and locations of Electricity Transformers"
 msgstr ""
-

--- a/locale/pot/advanced/chapter-12.pot
+++ b/locale/pot/advanced/chapter-12.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2010-2024 pgRouting Developers
-# This file is distributed under the same license as the Workshop FOSS4G Belém package.
+# Copyright (C) 2010-2025 pgRouting Developers
+# This file is distributed under the same license as the Workshop FOSS4G Auckland package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
+"Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:44+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -129,7 +129,7 @@ msgid "It can logically \"snap\" nearby vertices within a certain tolerance by a
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:102
-msgid "Creates a vertices table related to it."
+msgid "Creates a ways_vertices_pgr table related to it."
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:103
@@ -173,7 +173,7 @@ msgid "To verify that there is a basic `Routing Network Topology`:"
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:153
-msgid "Also a new table containing the vertices information was created:"
+msgid "Also a new table containing the ways_vertices_pgr information was created:"
 msgstr ""
 
 #: ../../build/docs/advanced/chapter-12.rst:159

--- a/locale/pot/basic/graphs.pot
+++ b/locale/pot/basic/graphs.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-03 17:35+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -172,7 +172,7 @@ msgid "Description of the function can be found in `pgr_extractVertices <https:/
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:144
-msgid "Exercise 1: Create a vertices table"
+msgid "Exercise 1: Create a ways_vertices_pgr table"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:147
@@ -187,7 +187,7 @@ msgid "Problem"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:148
-msgid "Create the vertices table corresponding to the edges in ``ways``."
+msgid "Create the ways_vertices_pgr table corresponding to the edges in ``ways``."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:151
@@ -218,19 +218,19 @@ msgid "From the requirements, a fully connected graph is needed, therefore addin
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:170
-msgid "Reviewing the description of the vertices table"
+msgid "Reviewing the description of the ways_vertices_pgr table"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:180
-msgid "Inspecting the information on the vertices table"
+msgid "Inspecting the information on the ways_vertices_pgr table"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:193
-msgid "Exercise 2: Fill up other columns in the vertices table"
+msgid "Exercise 2: Fill up other columns in the ways_vertices_pgr table"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:197
-msgid "Fill up geometry information on the vertices table."
+msgid "Fill up geometry information on the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:201
@@ -242,7 +242,7 @@ msgid "Update the ``geom`` and ``osm_id`` columns"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:213
-msgid "The update based on the ``source`` column from ``ways`` table and the ``id`` column of the vertices table."
+msgid "The update based on the ``source`` column from ``ways`` table and the ``id`` column of the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:215
@@ -261,7 +261,7 @@ msgid "Verification"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:230
-msgid "Not expecting to be done due to the fact that some vertices are dead ends."
+msgid "Not expecting to be done due to the fact that some ways_vertices_pgr are dead ends."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:242
@@ -269,7 +269,7 @@ msgid "Continue update the ``geom`` and ``osm_id`` columns"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:243
-msgid "The update based on the ``target`` column from ``ways`` table and the ``id`` column of the vertices table."
+msgid "The update based on the ``target`` column from ``ways`` table and the ``id`` column of the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:245
@@ -305,7 +305,7 @@ msgid "Description of the function can be found in `pgr_connectedComponents <htt
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:309
-msgid "Exercise 3: Set components on edges and vertices tables"
+msgid "Exercise 3: Set components on edges and ways_vertices_pgr tables"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:313
@@ -317,11 +317,11 @@ msgid "Create additional columns on the edges tables."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:329
-msgid "Use the ``pgr_connectedComponents`` to fill up the vertices table."
+msgid "Use the ``pgr_connectedComponents`` to fill up the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:330
-msgid "Use the results to store the component numbers on the vertices table."
+msgid "Use the results to store the component numbers on the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:343
@@ -337,7 +337,7 @@ msgid "Answer the following questions:"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:361
-msgid "How many components are in the vertices table?"
+msgid "How many components are in the ways_vertices_pgr table?"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:362
@@ -353,7 +353,7 @@ msgid "Get the component with the maximum number of edges."
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:369
-msgid "1. How many components are in the vertices table?"
+msgid "1. How many components are in the ways_vertices_pgr table?"
 msgstr ""
 
 #: ../../build/docs/basic/graphs.rst:370

--- a/locale/pot/basic/pedestrian.pot
+++ b/locale/pot/basic/pedestrian.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-28 19:15+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -288,22 +288,6 @@ msgstr ""
 
 #: ../../build/docs/scripts/basic/pedestrian/note_1.txt:1
 msgid "Inspecting the results, looking for totals (edge = -1):"
-msgstr ""
-
-#: ../../build/docs/scripts/basic/pedestrian/note_1.txt:3
-msgid "From 10832 to vertex 11046 takes 9.82 minutes (seq = 134)"
-msgstr ""
-
-#: ../../build/docs/scripts/basic/pedestrian/note_1.txt:5
-msgid "From 10832 to vertex 14824 takes 10.85 minutes (seq = 185)"
-msgstr ""
-
-#: ../../build/docs/scripts/basic/pedestrian/note_1.txt:7
-msgid "From 593 to vertex 11046 takes 9.07 minutes (seq = 50)"
-msgstr ""
-
-#: ../../build/docs/scripts/basic/pedestrian/note_1.txt:9
-msgid "From 593 to vertex 14824 takes 9.04 minutes (seq = 85)"
 msgstr ""
 
 #: ../../build/docs/basic/pedestrian.rst:248

--- a/locale/pot/un_sdg/sdg11-cities.pot
+++ b/locale/pot/un_sdg/sdg11-cities.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2010-2024 pgRouting Developers
-# This file is distributed under the same license as the Workshop FOSS4G Belém package.
+# Copyright (C) 2010-2025 pgRouting Developers
+# This file is distributed under the same license as the Workshop FOSS4G Auckland package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
+"Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-10 17:09+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -210,7 +210,7 @@ msgid "A sub-query is created to find out all the connected components. After th
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:251
-msgid "Create a vertices table."
+msgid "Create a ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:262
@@ -218,11 +218,11 @@ msgid "Fill up the ``x``, ``y`` and ``geom`` columns."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:273
-msgid "Add a ``component`` column on the edges and vertices tables."
+msgid "Add a ``component`` column on the edges and ways_vertices_pgr tables."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:284
-msgid "Fill up the ``component`` column on the vertices table."
+msgid "Fill up the ``component`` column on the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg11-cities.rst:295

--- a/locale/pot/un_sdg/sdg3-health.pot
+++ b/locale/pot/un_sdg/sdg3-health.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2010-2024 pgRouting Developers
-# This file is distributed under the same license as the Workshop FOSS4G Belém package.
+# Copyright (C) 2010-2025 pgRouting Developers
+# This file is distributed under the same license as the Workshop FOSS4G Auckland package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
+"Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:44+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -400,7 +400,7 @@ msgid "``pgr_connectedComponents``"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:430
-msgid "Create a vertices table."
+msgid "Create a ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:441
@@ -408,11 +408,11 @@ msgid "Fill up the ``x``, ``y`` and ``geom`` columns."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:452
-msgid "Add a ``component`` column on the edges and vertices tables."
+msgid "Add a ``component`` column on the edges and ways_vertices_pgr tables."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:463
-msgid "Fill up the ``component`` column on the vertices table."
+msgid "Fill up the ``component`` column on the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:474
@@ -428,7 +428,7 @@ msgid "Delete edges not belonging to the most connected component."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:507
-msgid "Delete vertices not belonging to the most connected component."
+msgid "Delete ways_vertices_pgr not belonging to the most connected component."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:518
@@ -472,7 +472,7 @@ msgid "Exercise 13: Find the closest road vertex"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:549
-msgid "There are multiple road vertices near the hospital. Create a function to find the geographically closest road vertex. ``closest_vertex`` function takes geometry of other table as input and gives the gid of the closest vertex as output by comparing ``geom`` of both the tables."
+msgid "There are multiple road ways_vertices_pgr near the hospital. Create a function to find the geographically closest road vertex. ``closest_vertex`` function takes geometry of other table as input and gives the gid of the closest vertex as output by comparing ``geom`` of both the tables."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg3-health.rst:558

--- a/locale/pot/un_sdg/sdg7-energy.pot
+++ b/locale/pot/un_sdg/sdg7-energy.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2010-2024 pgRouting Developers
-# This file is distributed under the same license as the Workshop FOSS4G Belém package.
+# Copyright (C) 2010-2025 pgRouting Developers
+# This file is distributed under the same license as the Workshop FOSS4G Auckland package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Workshop FOSS4G Belém 3.0\n"
+"Project-Id-Version: Workshop FOSS4G Auckland 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:44+0000\n"
+"POT-Creation-Date: 2026-03-30 19:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -117,7 +117,7 @@ msgid "``pgr_connectedComponents``"
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:106
-msgid "Create a vertices table."
+msgid "Create a ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:117
@@ -125,11 +125,11 @@ msgid "Fill up the ``x``, ``y`` and ``geom`` columns."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:128
-msgid "Add a ``component`` column on the edges and vertices tables."
+msgid "Add a ``component`` column on the edges and ways_vertices_pgr tables."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:139
-msgid "Fill up the ``component`` column on the vertices table."
+msgid "Fill up the ``component`` column on the ways_vertices_pgr table."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:150
@@ -145,7 +145,7 @@ msgid "Delete edges not belonging to the most connected component."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:183
-msgid "Delete vertices not belonging to the most connected component."
+msgid "Delete ways_vertices_pgr not belonging to the most connected component."
 msgstr ""
 
 #: ../../build/docs/un_sdg/sdg7-energy.rst:195


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Replaced table name `vertices` with `ways_vertices_pgr` in SQL scripts
- Updated references in workshop documentation (.rst files)
- Left conceptual uses of the word "vertices"  unchanged

The workshop scripts referenced a table called `vertices` which does not exist in the standard osm2pgrouting schema. The correct table is `ways_vertices_pgr`, which maps OSM IDs to internal pgRouting vertex IDs.

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated tutorials, exercises, and examples to consistently reference the pgRouting-generated ways_vertices_pgr table instead of generic "vertices".
  * Updated routing examples and images to source edges from the canonical ways dataset (replacing prior walk_net/vehicle_net references) so examples align with the current routing graph and vertex table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->