### PR TITLE
Fix workshop typos

### DIFF
--- a/docs/basic/data.rst
+++ b/docs/basic/data.rst
@@ -40,7 +40,7 @@ Information about installing OSGeoLive can be found on
 Create a pgRouting compatible database
 -------------------------------------------------------------------------------
 
-.. note:: Depending on the postgres configuration :code:`-U <user>` is needed on
+.. note:: Depending on the Postgres configuration :code:`-U <user>` is needed on
    :code:`psql` commands
 
 .. literalinclude:: ../scripts/get_data/process_osgeolive_data.sh

--- a/docs/basic/data.rst
+++ b/docs/basic/data.rst
@@ -95,8 +95,8 @@ due to changes since @DATE_OF_DATA@.
   BBOX="@PGR_WORKSHOP_CITY_BBOX@"
   wget --progress=dot:mega -O "$CITY.osm" "http://www.overpass-api.de/api/xapi?*[bbox=\$\{BBOX\}][@meta]"
 
-More information about how to download OpenStreetMap data can be found in
-https://wiki.openstreetmap.org/wiki/Downloading_data
+More information about how to download OpenStreetMap data can be found 
+`here <https://wiki.openstreetmap.org/wiki/Downloading_data>`_.
 
 An alternative for very large areas is to use the download services of
 `Geofabrik <https://download.geofabrik.de>`_.

--- a/docs/basic/graphs.rst
+++ b/docs/basic/graphs.rst
@@ -17,7 +17,7 @@ Graphs
 
 .. contents:: Chapter Contents
 
-Different application require different graphs. This chapter covers how to
+Different applications require different graphs. This chapter covers how to
 discard disconnected segments and different approaches to create graphs.
 
 pgRouting functions in this chapter
@@ -29,10 +29,10 @@ pgRouting functions in this chapter
 The graph requirements
 ===============================================================================
 
-In this chapter there are three graph requirements. It consists on three graphs
-based on a **fully connected** graph derived from ``ways``: two for different types
-of vehicles and one for pedestrian, the source and the target in all of them are
-based on the ``source`` and ``target``.
+This chapter requires the creation of three distinct routing graphs derived from
+``ways``. These consist of two vehicle-specific graphs and one pedestrian 
+graph, all of which utilize the standard ``source`` and ``target`` to determine 
+routing paths.
 
 The description of the graphs:
 
@@ -56,7 +56,7 @@ The description of the graphs:
 - Pedestrians:
 
   - Walk on the whole @PGR_WORKSHOP_CITY@ area.
-  - Can only use pedestrian only ways:
+  - Can only use pedestrian-only ways:
 
     - `pedestrian`, `steps`, `footway`, `path`, `cycleway`
 
@@ -68,7 +68,7 @@ Configuration from osm2pgrouting
 When dealing with data, being aware of what kind of data is being used can
 improve results.
 
-* Vehicles can not circulate on pedestrian ways
+* Vehicles cannot circulate on pedestrian ways
 
 .. image:: images/graphs/pedestrian_only_roads.png
   :scale: 25%
@@ -96,7 +96,7 @@ additional table: ``configuration``.
 
 |
 
-In the image above there is a detail of the ``tag_id`` of the roads.
+In the image above, there is a detail of the ``tag_id`` of the roads.
 
 .. rubric:: The `OSM highway <https://wiki.openstreetmap.org/wiki/Key:highway>`__
    types:
@@ -110,7 +110,7 @@ In the image above there is a detail of the ``tag_id`` of the roads.
 
    .. literalinclude:: ../scripts/basic/graphs/configuration_contents.txt
 
-Also, on the ``ways`` table there is a column that can be used to ``JOIN`` with the ``configuration`` table.
+Also, on the ``ways`` table, there is a column that can be used to ``JOIN`` with the ``configuration`` table.
 
 .. rubric:: The configuration types in the @PGR_WORKSHOP_CITY@ data
 

--- a/docs/basic/pedestrian.rst
+++ b/docs/basic/pedestrian.rst
@@ -14,7 +14,7 @@ Pedestrian Routing
   :scale: 25%
   :align: center
 
-**pgRouting** was first called *pgDijkstra*, because it implemented only shortest
+**pgRouting** was first called *pgDijkstra* because it implemented only shortest
 path search with *Dijkstra* algorithm. Later other functions were added and the
 library was renamed to pgRouting.
 

--- a/docs/basic/pedestrian.rst
+++ b/docs/basic/pedestrian.rst
@@ -28,7 +28,7 @@ pgRouting functions in this chapter
 pgr_dijkstra
 -------------------------------------------------------------------------------
 
-Dijkstra algorithm was the first algorithm implemented in pgRouting. It doesn't
+Dijkstra algorithm was the first algorithm implemented in pgRouting. It does not
 require other attributes than the identifiers ``id``, ``source`` and ``target``
 and the weights ``cost`` and ``reverse_cost``.
 

--- a/docs/basic/sql_function.rst
+++ b/docs/basic/sql_function.rst
@@ -17,14 +17,12 @@ SQL function
 
 .. contents:: Chapter Contents
 
-pgRouting functions provide `low level` interface.
+While pgRouting functions provide a low-level interface, developing for a higher-level 
+application requires these requirements to be represented directly in the SQL queries. 
+As these SQL queries get more complex, it is desirable to store them in PostgreSQL 
+stored procedures or functions. Stored procedures or functions are an effective way 
+to wrap application logic, in this case, related to routing logic and requirements.
 
-When developing for a `higher level` application,
-the requirements need to be represented in the SQL queries.
-As these SQL queries get more complex, it is desirable to store them in postgreSQL
-stored procedures or functions.
-Stored procedures or functions are an effective way to wrap application logic, in this case,
-related to routing logic and requirements.
 
 The function requirements
 ===============================================================================
@@ -132,7 +130,7 @@ Geometry handling
 ===============================================================================
 
 From pgRouting point of view, the geometry is part of the additional
-information, needed on the results for an application. Therefore ``JOIN`` the
+information needed on the results for an application. Therefore ``JOIN`` the
 results with other tables that contain the geometry and for further processing
 with PostGIS functions.
 

--- a/docs/basic/vehicle.rst
+++ b/docs/basic/vehicle.rst
@@ -15,7 +15,7 @@ Vehicle Routing
   :scale: 25%
   :align: center
 
-Routing, is not limited to pedestrians and most of the time is used for routing vehicles.
+Routing is not limited to pedestrians and most of the time is also used for routing vehicles.
 
 .. contents:: Chapter Contents
 
@@ -33,7 +33,7 @@ A query for vehicle routing generally differs from routing for pedestrians:
   * Euros
   * Pesos
   * Dollars
-  * CO\ :sub:`2`\ emissions
+  * CO\ :sub:`2`\  emissions
   * Wear and tear on the vehicle, etc.
 
 * The ``reverse_cost`` attribute must be taken into account on two way streets.

--- a/docs/basic/withPoints.rst
+++ b/docs/basic/withPoints.rst
@@ -14,10 +14,10 @@ Routing using points
   :width: 250pt
   :align: center
 
-Other kind of functions are `pl/pgsql
-<https://www.postgresql.org/docs/current/plpgsql.html>`__. As the applications
-requirements become more complex, building queries and storing queries in a
-variable becomes necessary
+
+For more advanced requirements, you can utilize `PL/pgSQL <https://www.postgresql.org/docs/current/plpgsql.html>`_. As application logic grows more complex, using PL/pgSQL
+to dynamically construct SQL queries and execute them using internal variables becomes necessary.
+
 
 pgRouting functions in this chapter
 

--- a/docs/general-intro/introduction.rst
+++ b/docs/general-intro/introduction.rst
@@ -19,7 +19,7 @@ pgRouting: `Basic`_ and `Advanced`_.
 Basic
 -------------------------------------------------------------------------------
 
-will demonstrate the routing functionality by
+This level will demonstrate the routing functionality by
 providing examples using |osm-web| road network data from @PGR_WORKSHOP_CITY@.
 Covering topics from how to prepare the data, making routing queries,
 understanding the results, up to writing a custom 'plpgsql' function that can be

--- a/docs/general-intro/introduction.rst
+++ b/docs/general-intro/introduction.rst
@@ -66,7 +66,7 @@ Aknowledments
   :width: 200
   :target: https://www.erosion.dev/
 
-.. rubric:: Developers & Presenters of @WORKSHOP_AREA@ workshop:
+.. rubric:: Developers & presenters of @WORKSHOP_AREA@ workshop:
 
 * *Vicky Vergara* is a freelance developer from Mexico. She is the core developer
   of the pgRouting project and a GSoC Mentor. She also serves as an OSGeo Charter member.

--- a/docs/general-intro/introduction.rst
+++ b/docs/general-intro/introduction.rst
@@ -30,11 +30,11 @@ integrated with other FOSS tools.
 * Importing |osm-web| road network data.
 * Using pgRouting algorithms.
 * Writing advanced queries.
-* Writing a custom PostgreSQL stored procedure in `plpgsql`
+* Writing a custom PostgreSQL stored procedure in `plpgsql`.
 
 .. rubric:: Prerequisites
 
-* Workshop level: basic.
+* Workshop level: basic
 * Previous knowledge: SQL (PostgreSQL, PostGIS)
 * Equipments: `OSGeoLive <https://live.osgeo.org>`__ (@OSGeoLive_VERSION@)
 
@@ -47,7 +47,7 @@ section covers several graph problems that can be solved using pgRouting.
 
 .. rubric:: Prerequisites
 
-* Workshop level: Advanced.
+* Workshop level: Advanced
 * Previous knowledge: SQL (PostgreSQL, PostGIS, pgRouting)
 * Equipments: `OSGeoLive <https://live.osgeo.org>`__ (@OSGeoLive_VERSION@)
 
@@ -66,16 +66,16 @@ Aknowledments
   :width: 200
   :target: https://www.erosion.dev/
 
-.. rubric:: Developers & presenters of @WORKSHOP_AREA@ workshop:
+.. rubric:: Developers & Presenters of @WORKSHOP_AREA@ workshop:
 
-* *Vicky Vergara* Is a freelance developer from Mexico. She's the core developer
-  of pgRouting project and GSoC Mentor. OSGeo Charter member.
+* *Vicky Vergara* is a freelance developer from Mexico. She is the core developer
+  of the pgRouting project and a GSoC Mentor. She also serves as an OSGeo Charter member.
 
-* *Ramón Ríos* Is a freelance developer from Mexico. Lead engenieer for
-  ParkUpFront
+* *Ramón Ríos* is a freelance developer from Mexico. He is the Lead Engineer for
+  ParkUpFront.
 
 
-.. rubric:: Past and present tutors and developers
+.. rubric:: Past and present tutors and developers:
 
 Daniel Kastl,
 José Ríos,
@@ -87,7 +87,7 @@ Ramón Ríos,
 Rohith Reddy,
 Vicky Vergara
 
-.. rubric:: Past and present supporters
+.. rubric:: Past and present supporters:
 
 Georepublic,
 Paragon Corporation

--- a/docs/general-intro/osgeolive.rst
+++ b/docs/general-intro/osgeolive.rst
@@ -91,20 +91,20 @@ Open the Virtual Box
 
 Click on ``New`` and fill with the following information
 
-* **Name** OSGeoLive @OSGeoLive_VERSION@
-* **Type** Linux
-* **Version** Ubuntu (64-bit)
-* **Memory size** 4096
-* **Hard disk** Create a virtual hard disk now
+* **Name**: OSGeoLive @OSGeoLive_VERSION@
+* **Type**: Linux
+* **Version**: Ubuntu (64-bit)
+* **Memory size**: 4096
+* **Hard disk**: Create a virtual hard disk now
 
 .. image:: /images/osgeolive/createVirtualMachine.png
 
 Click on ``Create`` and fill with the following information
 
-* **File location** Choose a suitable location for the Virtual Hard Disk
-* **File size** 10.0GB
-* **Hard disk file type** VDI (VirtualBox Disk image)
-* **Storage on physical hard disk** Dynamically allocated
+* **File location**: Choose a suitable location for the Virtual Hard Disk
+* **File size**: 10.0GB
+* **Hard disk file type**: VDI (VirtualBox Disk image)
+* **Storage on physical hard disk**: Dynamically allocated
 
 .. image:: /images/osgeolive/createVirtualHardDisk.png
 
@@ -114,15 +114,15 @@ Install OSGeoLive's ISO
 On Storage it reads:
 
 :Controller: IDE
-:IDE Secondary Device 0: [Optical Drive] empty
+:IDE Secondary Device 0: [Optical Drive] Empty
 
 .. image:: /images/osgeolive/afterCreateVM.png
 
-Choose ``Storage`` from the virtual box traits and clink on ``Empty``
+Choose ``Storage`` from the virtual box traits and click on ``Empty``
 
 .. image:: /images/osgeolive/storageWithEmpty.png
 
-Click on the small disk icon and select **Choose/Create a Virtual Disk**
+Click on the small disk icon and select ``Choose/Create a Virtual Optical Disk``
 
 .. image:: /images/osgeolive/chooseVirtualDisk.png
 
@@ -130,7 +130,7 @@ Navigate to the location where the ISO was installed
 
 .. image:: /images/osgeolive/chooseOSGeoLiveISO.png
 
-Instead of empty, now it has the ISO installed
+Instead of ``Empty`` now it has the ISO installed
 
 .. image:: /images/osgeolive/withISOinstalled.png
 
@@ -145,7 +145,7 @@ The installation now reads:
 Start OSGeoLive
 ...............................................................................
 
-Click on ``Start`` button, and click on ``capture``, to capture the mouse
+Click on ``Start`` button and then on ``capture`` button to capture the mouse
 movements
 
 .. image:: /images/osgeolive/captureMouse.png

--- a/docs/general-intro/overview.rst
+++ b/docs/general-intro/overview.rst
@@ -90,23 +90,15 @@ OpenStreetMap Overview
     :align: center
     :target: https://www.openstreetmap.org
 
-OpenStreetMap (OSM) is dedicated to creating and providing free, 
-unrestricted global geographic data. Unlike traditional maps that 
-impose legal or technical limitations, OSM eliminates the data silos 
-that restrict creative and productive use, enabling developers and 
-researchers to leverage spatial data in innovative ways.
+    OpenStreetMap (OSM) is dedicated to creating and providing geographic 
+    data, such as street maps, worldwide, for free. Most maps considered 
+    'free' actually have legal or technical restrictions on their use. 
+    These restrictions hold back anyone from using them in creative, 
+    productive or unexpected ways, and make every map a silo of data and effort.
 
---`OSM Press Wiki <https://wiki.openstreetmap.org/wiki/Press>`_
+    -- `Source: OSM Press Wiki <https://wiki.openstreetmap.org/wiki/Press>`_
 
-"OpenStreetMap (OSM) is dedicated to creating and providing geographic data,
-such as street maps, worldwide, for free. Most maps considered "free" actually
-have legal or technical restrictions on their use. These restrictions hold back
-anyone from using them in creative, productive or unexpected ways, and make
-every map a silo of data and effort."
-
-(Source: https://wiki.openstreetmap.org/wiki/Press)
-
-OpenStreetMap is an adequate data source for pgRouting, because it has no
+OpenStreetMap is an incredible data source for pgRouting because it has no
 technical restrictions in terms of processing the data. Data availability still
 varies from country to country, but the worldwide coverage is improving day by
 day.

--- a/docs/general-intro/overview.rst
+++ b/docs/general-intro/overview.rst
@@ -58,8 +58,8 @@ pgRouting is an open source software available under the GPLv2 license and is
 supported and maintained by the pgRouting community.
 
 `pgRouting <https://pgrouting.org>`_ is part of `OSGeo Community Projects
-<https://wiki.osgeo.org/wiki/OSGeo_Community_Projects>`__ of the `OSGeo
-Foundation <https://www.osgeo.org>`__ and included on `OSGeoLive
+<https://wiki.osgeo.org/wiki/OSGeo_Community_Projects>`__ under `OSGeo
+Foundation <https://www.osgeo.org>`__. It is included on `OSGeoLive
 <https://live.osgeo.org/en/overview/pgrouting_overview.html>`__.
 
 :Check it out on OSGeoLive: https://live.osgeo.org/en/overview/pgrouting_overview.html
@@ -90,6 +90,13 @@ OpenStreetMap Overview
     :align: center
     :target: https://www.openstreetmap.org
 
+OpenStreetMap (OSM) is dedicated to creating and providing free, 
+unrestricted global geographic data. Unlike traditional maps that 
+impose legal or technical limitations, OSM eliminates the data silos 
+that restrict creative and productive use, enabling developers and 
+researchers to leverage spatial data in innovative ways.
+
+--`OSM Press Wiki <https://wiki.openstreetmap.org/wiki/Press>`_
 
 "OpenStreetMap (OSM) is dedicated to creating and providing geographic data,
 such as street maps, worldwide, for free. Most maps considered "free" actually

--- a/docs/general-intro/overview.rst
+++ b/docs/general-intro/overview.rst
@@ -90,13 +90,13 @@ OpenStreetMap Overview
     :align: center
     :target: https://www.openstreetmap.org
 
-    OpenStreetMap (OSM) is dedicated to creating and providing geographic 
-    data, such as street maps, worldwide, for free. Most maps considered 
-    'free' actually have legal or technical restrictions on their use. 
-    These restrictions hold back anyone from using them in creative, 
-    productive or unexpected ways, and make every map a silo of data and effort.
+OpenStreetMap (OSM) is dedicated to creating and providing geographic 
+data, such as street maps, worldwide, for free. Most maps considered 
+'free' actually have legal or technical restrictions on their use. 
+These restrictions hold back anyone from using them in creative, 
+productive or unexpected ways, and make every map a silo of data and effort.
 
-    -- `Source: OSM Press Wiki <https://wiki.openstreetmap.org/wiki/Press>`_
+Source: `OSM Press Wiki <https://wiki.openstreetmap.org/wiki/Press>`_
 
 OpenStreetMap is an incredible data source for pgRouting because it has no
 technical restrictions in terms of processing the data. Data availability still

--- a/docs/general-intro/overview.rst
+++ b/docs/general-intro/overview.rst
@@ -15,8 +15,8 @@ Software and Data Overview
     :target: https://www.osgeo.org/
 
 
-This workshop use several free and open source software for geospatial tools.
-Most of the free and open source software for geospatial tools that are related to
+This workshop uses several free and open source softwares for geospatial tools.
+Most of these softwares are related to
 other open source software projects. Here we mention the most important ones.
 
 .. contents:: Chapter Contents
@@ -52,18 +52,17 @@ Some of the pgRouting library core features are:
 * `Bi-directional A* <https://docs.pgrouting.org/latest/en/pgr_bdAstar.html>`__
 * `Traveling Salesperson Problem <https://docs.pgrouting.org/latest/en/pgr_TSP.html>`__
 * `Driving Distance <https://docs.pgrouting.org/latest/en/pgr_drivingDistance.html>`__
-* many more!!!
+* `and many more <https://docs.pgrouting.org/latest/en/routingFunctions.html>`_
 
-pgRouting is an Open Source Software, available under the GPLv2 license and is
-supported and maintained by a the pgRouting community.
+pgRouting is an open source software available under the GPLv2 license and is
+supported and maintained by the pgRouting community.
 
-pgRouting is a part of `OSGeo Community Projects
+`pgRouting <https://pgrouting.org>`_ is part of `OSGeo Community Projects
 <https://wiki.osgeo.org/wiki/OSGeo_Community_Projects>`__ of the `OSGeo
 Foundation <https://www.osgeo.org>`__ and included on `OSGeoLive
 <https://live.osgeo.org/en/overview/pgrouting_overview.html>`__.
 
-:Website: https://pgrouting.org
-:OSGeoLive: https://live.osgeo.org/en/overview/pgrouting_overview.html
+:Check it out on OSGeoLive: https://live.osgeo.org/en/overview/pgrouting_overview.html
 
 
 osm2pgrouting Overview


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Went through the webpage and noticed the OSM overview has been removed due to indentation error. It has been corrected.

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved clarity and wording throughout workshop guides covering routing concepts, installation instructions, and data handling
  * Enhanced formatting and structure in introductory materials and foundational routing tutorials
  * Updated explanations for better understanding of pgRouting functionality and practical use cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->